### PR TITLE
app: add configurable screen orientation

### DIFF
--- a/app/src/main/java/com/anland/termux/MainActivity.java
+++ b/app/src/main/java/com/anland/termux/MainActivity.java
@@ -7,6 +7,7 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.hardware.display.DisplayManager;
 import android.content.SharedPreferences;
@@ -72,6 +73,7 @@ public class MainActivity extends Activity
     private boolean mKeyboardFloating = false;
     // Persistent "tap to open Settings" notification, toggleable in Settings > General.
     private static final String KEY_NOTIFICATION_ENABLED = "settings_notification";
+    private static final String KEY_SCREEN_ORIENTATION = "screen_orientation";
     // System soft-keyboard bridge: hidden input, text forwarding and toggle.
     private SystemIME systemIme;
     private int mImeBottom = 0;   // last IME bottom inset
@@ -151,6 +153,8 @@ public class MainActivity extends Activity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        applyScreenOrientation();
 
         sInstance = this;
         clipboard = new Clipboard(this);
@@ -335,6 +339,8 @@ public class MainActivity extends Activity
     protected void onResume() {
         super.onResume();
 
+        applyScreenOrientation();
+
         // Show settings notification while in foreground, unless disabled in Settings.
         if (getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
                 .getBoolean(KEY_NOTIFICATION_ENABLED, true)) {
@@ -395,6 +401,32 @@ public class MainActivity extends Activity
         SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         isTouchpadMode = prefs.getBoolean(KEY_TOUCHPAD_MODE, false);
         virtualTouchpad.setAccelStrength(prefs.getFloat(KEY_MOUSE_ACCEL, 1.0f));
+    }
+
+    private void applyScreenOrientation() {
+        String orientation = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .getString(KEY_SCREEN_ORIENTATION, "auto");
+        int requestedOrientation;
+        switch (orientation) {
+            case "portrait":
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
+                break;
+            case "landscape":
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+                break;
+            case "reverse portrait":
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
+                break;
+            case "reverse landscape":
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
+                break;
+            default:
+                requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED;
+                break;
+        }
+
+        if (getRequestedOrientation() != requestedOrientation)
+            setRequestedOrientation(requestedOrientation);
     }
 
     @Override

--- a/app/src/main/java/com/anland/termux/SettingsActivity.java
+++ b/app/src/main/java/com/anland/termux/SettingsActivity.java
@@ -55,8 +55,14 @@ public class SettingsActivity extends Activity {
     private static final String KEY_EXTRA_KEYS_LAYOUT = "extra_keys_layout";
     private static final String KEY_KEYBOARD_FLOATING = "keyboard_floating";
     private static final String KEY_NOTIFICATION_ENABLED = "settings_notification";
+    private static final String KEY_SCREEN_ORIENTATION = "screen_orientation";
     private static final String DEFAULT_SOCKET_PATH = "/data/data/com.termux/files/usr/tmp/anland/display_daemon.sock";
     private static final int UNBOUND = -1;
+
+    // Stored values match Termux:X11's forceOrientation preference.
+    private static final String[] SCREEN_ORIENTATIONS = {
+        "auto", "portrait", "landscape", "reverse portrait", "reverse landscape"
+    };
 
     // ===== 新增：触摸板 Key =====
     private static final String KEY_TOUCHPAD_MODE = "touchpad_mode";
@@ -67,7 +73,7 @@ public class SettingsActivity extends Activity {
     private static final int[] LATENCY_MS = {0, 1, 3, 5, 10, 20};
 
     // Which secondary page is on screen. Back returns HOME -> exits the activity.
-    private enum Page { HOME, KEYBOARD, TOUCHPAD, CONNECTION, RESOLUTION, GENERAL }
+    private enum Page { HOME, KEYBOARD, TOUCHPAD, CONNECTION, DISPLAY, GENERAL }
     private Page currentPage = Page.HOME;
 
     private Button bindButton;
@@ -153,8 +159,8 @@ public class SettingsActivity extends Activity {
             R.string.cat_touchpad_subtitle, this::showTouchpadPage);
         addCategoryRow(root, R.string.section_connection,
             R.string.cat_connection_subtitle, this::showConnectionPage);
-        addCategoryRow(root, R.string.section_resolution,
-            R.string.cat_resolution_subtitle, this::showResolutionPage);
+        addCategoryRow(root, R.string.section_display,
+            R.string.cat_display_subtitle, this::showDisplayPage);
         addCategoryRow(root, R.string.cat_general_title,
             R.string.cat_general_subtitle, this::showGeneralPage);
 
@@ -271,10 +277,11 @@ public class SettingsActivity extends Activity {
         setContent(root);
     }
 
-    private void showResolutionPage() {
-        currentPage = Page.RESOLUTION;
-        LinearLayout root = newPage(R.string.section_resolution);
+    private void showDisplayPage() {
+        currentPage = Page.DISPLAY;
+        LinearLayout root = newPage(R.string.section_display);
         addResolutionSection(root);
+        addScreenOrientationSection(root);
         setContent(root);
     }
 
@@ -699,6 +706,13 @@ public class SettingsActivity extends Activity {
     private void addResolutionSection(LinearLayout root) {
     SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
 
+    TextView title = new TextView(this);
+    title.setText(R.string.section_resolution);
+    title.setTextSize(16);
+    title.setTypeface(Typeface.DEFAULT_BOLD);
+    title.setPadding(0, 0, 0, dp(8));
+    root.addView(title);
+
     // Width / height fields. Created first (but added below the preset picker) so
     // the picker can populate them; their TextWatchers are the single source of
     // truth that persists custom_width/custom_height.
@@ -763,6 +777,51 @@ public class SettingsActivity extends Activity {
     hint.setTextColor(Color.GRAY);
     hint.setPadding(0, dp(4), 0, 0);
     root.addView(hint);
+    }
+
+    private void addScreenOrientationSection(LinearLayout root) {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+
+        TextView title = new TextView(this);
+        title.setText(R.string.section_screen_orientation);
+        title.setTextSize(16);
+        title.setTypeface(Typeface.DEFAULT_BOLD);
+        title.setPadding(0, dp(24), 0, dp(8));
+        root.addView(title);
+
+        Spinner orientationSpinner = new Spinner(this);
+        orientationSpinner.setAdapter(new ArrayAdapter<>(this,
+            android.R.layout.simple_spinner_dropdown_item,
+            getResources().getStringArray(R.array.screen_orientation_labels)));
+
+        String current = prefs.getString(KEY_SCREEN_ORIENTATION, SCREEN_ORIENTATIONS[0]);
+        int selected = 0;
+        for (int i = 0; i < SCREEN_ORIENTATIONS.length; i++) {
+            if (SCREEN_ORIENTATIONS[i].equals(current)) {
+                selected = i;
+                break;
+            }
+        }
+        orientationSpinner.setSelection(selected);
+        orientationSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                prefs.edit()
+                    .putString(KEY_SCREEN_ORIENTATION, SCREEN_ORIENTATIONS[position])
+                    .apply();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {}
+        });
+        root.addView(orientationSpinner);
+
+        TextView hint = new TextView(this);
+        hint.setText(R.string.screen_orientation_hint);
+        hint.setTextSize(12);
+        hint.setTextColor(Color.GRAY);
+        hint.setPadding(0, dp(4), 0, 0);
+        root.addView(hint);
     }
 
     // Maps a res_preset_labels index to {width, height}, or null for the index-0

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -9,7 +9,9 @@
     <string name="section_custom_layout">自訂擴充按鍵配置</string>
     <string name="section_touchpad">觸控板設定</string>
     <string name="section_connection">連線</string>
+    <string name="section_display">顯示</string>
     <string name="section_resolution">顯示解析度</string>
+    <string name="section_screen_orientation">螢幕方向</string>
     <string name="section_notification">設定通知</string>
 
     <!-- Settings home: category rows and back navigation -->
@@ -19,7 +21,7 @@
     <string name="cat_touchpad_title">觸控板與滑鼠</string>
     <string name="cat_touchpad_subtitle">觸控板模式與指標靈敏度</string>
     <string name="cat_connection_subtitle">socket、root、麥克風、相機與音訊延遲</string>
-    <string name="cat_resolution_subtitle">輸出解析度與預設</string>
+    <string name="cat_display_subtitle">解析度與螢幕方向</string>
     <string name="cat_general_title">一般</string>
     <string name="cat_general_subtitle">設定通知</string>
 
@@ -76,6 +78,8 @@
     <string name="height_hint">高度（例如 1080）</string>
     <string name="resolution_hint">選擇預設或手動輸入數值。填 0 表示原生解析度。\"Screen ×\" 會依本裝置面板（橫向）縮放。下次連線時生效。</string>
 
+    <string name="screen_orientation_hint">控制桌面檢視的螢幕方向。返回桌面時生效。</string>
+
     <!-- Settings notification -->
     <string name="notification_switch">顯示設定通知</string>
     <string name="notification_hint">應用程式開啟時顯示一則常駐通知，點按可直接進入設定。關閉後不再顯示。下次返回應用程式時生效。</string>
@@ -127,5 +131,13 @@
         <item>螢幕 × 0.75</item>
         <item>螢幕 × 0.5</item>
         <item>螢幕 × 0.25</item>
+    </string-array>
+
+    <string-array name="screen_orientation_labels">
+        <item>自動</item>
+        <item>直向</item>
+        <item>橫向</item>
+        <item>反向直向</item>
+        <item>反向橫向</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -9,7 +9,9 @@
     <string name="section_custom_layout">自定义扩展按键布局</string>
     <string name="section_touchpad">触摸板设置</string>
     <string name="section_connection">连接</string>
+    <string name="section_display">显示</string>
     <string name="section_resolution">显示分辨率</string>
+    <string name="section_screen_orientation">屏幕方向</string>
     <string name="section_notification">设置通知</string>
 
     <!-- Settings home: category rows and back navigation -->
@@ -19,7 +21,7 @@
     <string name="cat_touchpad_title">触摸板与鼠标</string>
     <string name="cat_touchpad_subtitle">触摸板模式与指针灵敏度</string>
     <string name="cat_connection_subtitle">套接字、root、麦克风、摄像头与音频延迟</string>
-    <string name="cat_resolution_subtitle">输出分辨率与预设</string>
+    <string name="cat_display_subtitle">分辨率与屏幕方向</string>
     <string name="cat_general_title">通用</string>
     <string name="cat_general_subtitle">设置通知</string>
 
@@ -76,6 +78,8 @@
     <string name="height_hint">高度（例如 1080）</string>
     <string name="resolution_hint">选择预设或手动输入数值。填 0 表示原生分辨率。\"Screen ×\" 会按本设备面板（横向）缩放。下次连接时生效。</string>
 
+    <string name="screen_orientation_hint">控制桌面视图的屏幕方向。返回桌面时生效。</string>
+
     <!-- Settings notification -->
     <string name="notification_switch">显示设置通知</string>
     <string name="notification_hint">应用打开时显示一条常驻通知，点击可直接进入设置。关闭后不再显示。下次返回应用时生效。</string>
@@ -127,5 +131,13 @@
         <item>屏幕 × 0.75</item>
         <item>屏幕 × 0.5</item>
         <item>屏幕 × 0.25</item>
+    </string-array>
+
+    <string-array name="screen_orientation_labels">
+        <item>自动</item>
+        <item>竖屏</item>
+        <item>横屏</item>
+        <item>反向竖屏</item>
+        <item>反向横屏</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,9 @@
     <string name="section_custom_layout">Custom Extra Keys Layout</string>
     <string name="section_touchpad">Touchpad Settings</string>
     <string name="section_connection">Connection</string>
+    <string name="section_display">Display</string>
     <string name="section_resolution">Display Resolution</string>
+    <string name="section_screen_orientation">Screen Orientation</string>
     <string name="section_notification">Settings Notification</string>
 
     <!-- Settings home: category rows and back navigation -->
@@ -19,7 +21,7 @@
     <string name="cat_touchpad_title">Touchpad &amp; Mouse</string>
     <string name="cat_touchpad_subtitle">Touchpad mode &amp; pointer sensitivity</string>
     <string name="cat_connection_subtitle">Socket, root, mic, camera &amp; audio latency</string>
-    <string name="cat_resolution_subtitle">Output resolution &amp; presets</string>
+    <string name="cat_display_subtitle">Resolution &amp; screen orientation</string>
     <string name="cat_general_title">General</string>
     <string name="cat_general_subtitle">Settings notification</string>
 
@@ -76,6 +78,8 @@
     <string name="height_hint">Height (e.g. 1080)</string>
     <string name="resolution_hint">Pick a preset or enter values manually. Leave 0 for native resolution. \"Screen ×\" scales this device\'s panel (landscape). Takes effect on next connect.</string>
 
+    <string name="screen_orientation_hint">Controls the desktop view orientation. Takes effect when you return to the desktop.</string>
+
     <!-- Settings notification -->
     <string name="notification_switch">Show settings notification</string>
     <string name="notification_hint">Show a persistent notification while the app is open; tapping it jumps straight to Settings. Turn off to hide it. Takes effect on next return to the app.</string>
@@ -127,5 +131,13 @@
         <item>Screen × 0.75</item>
         <item>Screen × 0.5</item>
         <item>Screen × 0.25</item>
+    </string-array>
+
+    <string-array name="screen_orientation_labels">
+        <item>Auto</item>
+        <item>Portrait</item>
+        <item>Landscape</item>
+        <item>Reverse portrait</item>
+        <item>Reverse landscape</item>
     </string-array>
 </resources>


### PR DESCRIPTION
- Rename the top-level “Display Resolution” settings entry to “Display”
- Move the existing resolution controls under a “Display Resolution” subsection
- Add a new “Screen Orientation” setting with the following options:
  - Auto
  - Portrait
  - Landscape
  - Reverse portrait
  - Reverse landscape
- Apply the selected orientation when the main activity starts or resumes
- Add English, Simplified Chinese, and Traditional Chinese translations

The orientation values and Android orientation mappings follow the Termux:X11 implementation.