### PR TITLE
app: add configurable display cutout handling

### DIFF
--- a/app/src/main/java/com/anland/termux/DisplayCutoutMode.java
+++ b/app/src/main/java/com/anland/termux/DisplayCutoutMode.java
@@ -1,0 +1,47 @@
+package com.anland.termux;
+
+import android.content.SharedPreferences;
+
+final class DisplayCutoutMode {
+    static final String KEY = "hide_display_cutout";
+
+    static final String HIDE_ALL = "hide_all";
+    static final String HIDE_ROUNDED_CORNERS_ONLY = "rounded_corners_only";
+    static final String HIDE_CUTOUT_ONLY = "cutout_only";
+    static final String HIDE_NONE = "none";
+
+    static final String[] VALUES = {
+        HIDE_ALL, HIDE_ROUNDED_CORNERS_ONLY, HIDE_CUTOUT_ONLY, HIDE_NONE
+    };
+
+    private DisplayCutoutMode() {}
+
+    static String get(SharedPreferences prefs) {
+        Object stored = prefs.getAll().get(KEY);
+        if (stored instanceof String && isValid((String) stored))
+            return (String) stored;
+
+        String mode = stored instanceof Boolean && !((Boolean) stored)
+            ? HIDE_NONE
+            : HIDE_ALL;
+        if (stored != null)
+            prefs.edit().putString(KEY, mode).apply();
+        return mode;
+    }
+
+    static boolean hidesCutout(String mode) {
+        return HIDE_ALL.equals(mode) || HIDE_CUTOUT_ONLY.equals(mode);
+    }
+
+    static boolean hidesRoundedCorners(String mode) {
+        return HIDE_ALL.equals(mode) || HIDE_ROUNDED_CORNERS_ONLY.equals(mode);
+    }
+
+    private static boolean isValid(String mode) {
+        for (String value : VALUES) {
+            if (value.equals(mode))
+                return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/com/anland/termux/MainActivity.java
+++ b/app/src/main/java/com/anland/termux/MainActivity.java
@@ -9,6 +9,9 @@ import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
+import android.graphics.Color;
+import android.graphics.Insets;
 import android.hardware.display.DisplayManager;
 import android.content.SharedPreferences;
 import android.os.Build;
@@ -20,6 +23,7 @@ import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.PointerIcon;
+import android.view.RoundedCorner;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -91,6 +95,7 @@ public class MainActivity extends Activity
     private float mPointerY = 0f;
     private boolean mPointerPositionKnown = false;
     private final float[] mTransformedPointerDelta = new float[2];
+    private String mDisplayCutoutMode = DisplayCutoutMode.HIDE_ALL;
     // Layout JSON the current bar was built from; used to detect edits on resume.
     private String mAppliedLayoutJson = "";
 
@@ -168,6 +173,8 @@ public class MainActivity extends Activity
 
         sInstance = this;
         clipboard = new Clipboard(this);
+        mDisplayCutoutMode = DisplayCutoutMode.get(
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE));
 
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
@@ -183,6 +190,7 @@ public class MainActivity extends Activity
         systemIme = new SystemIME(this, this);
 
         FrameLayout root = new FrameLayout(this);
+        root.setBackgroundColor(Color.BLACK);
         root.addView(surfaceView, new FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             FrameLayout.LayoutParams.MATCH_PARENT));
@@ -247,6 +255,7 @@ public class MainActivity extends Activity
             // stays in sync — otherwise reopening needs a second press.
             if (!insets.isVisible(WindowInsets.Type.ime()))
                 systemIme.releaseHiddenInput();
+            applyDisplaySafeInsets(insets);
             applyImeInset(insets);
             return v.onApplyWindowInsets(insets);
         });
@@ -341,8 +350,70 @@ public class MainActivity extends Activity
             ctrl.setSystemBarsBehavior(
                 WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
         }
-        getWindow().getAttributes().layoutInDisplayCutoutMode =
-            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+        WindowManager.LayoutParams attrs = getWindow().getAttributes();
+        attrs.layoutInDisplayCutoutMode = DisplayCutoutMode.hidesCutout(mDisplayCutoutMode)
+            ? WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+            : WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER;
+        getWindow().setAttributes(attrs);
+    }
+
+    private void applyDisplaySafeInsets(WindowInsets insets) {
+        Insets cutout = Insets.NONE;
+        // Android 15+ forces full-screen apps targeting API 35+ into cutout areas,
+        // even when NEVER is requested. Recreate Termux:X11's safe layout manually.
+        if (!DisplayCutoutMode.hidesCutout(mDisplayCutoutMode)
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM)
+            cutout = insets.getInsets(WindowInsets.Type.displayCutout());
+
+        int roundedCornerTop = 0;
+        int roundedCornerBottom = 0;
+        int roundedCornerLeft = 0;
+        int roundedCornerRight = 0;
+        if (!DisplayCutoutMode.hidesRoundedCorners(mDisplayCutoutMode)
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Keep full-width strips clear of the rounded corners, matching the
+            // rectangular safe area used below edge-to-edge input methods.
+            RoundedCorner topLeft = insets.getRoundedCorner(RoundedCorner.POSITION_TOP_LEFT);
+            RoundedCorner topRight = insets.getRoundedCorner(RoundedCorner.POSITION_TOP_RIGHT);
+            RoundedCorner bottomLeft = insets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_LEFT);
+            RoundedCorner bottomRight = insets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_RIGHT);
+            if (topLeft != null) {
+                roundedCornerTop = topLeft.getRadius();
+                roundedCornerLeft = topLeft.getRadius();
+            }
+            if (topRight != null) {
+                roundedCornerTop = Math.max(roundedCornerTop, topRight.getRadius());
+                roundedCornerRight = topRight.getRadius();
+            }
+            if (bottomLeft != null) {
+                roundedCornerBottom = bottomLeft.getRadius();
+                roundedCornerLeft = Math.max(roundedCornerLeft, bottomLeft.getRadius());
+            }
+            if (bottomRight != null) {
+                roundedCornerBottom = Math.max(roundedCornerBottom, bottomRight.getRadius());
+                roundedCornerRight = Math.max(roundedCornerRight, bottomRight.getRadius());
+            }
+        }
+
+        Insets safeInsets;
+        boolean avoidAllInLandscape = DisplayCutoutMode.HIDE_NONE.equals(mDisplayCutoutMode)
+            && getResources().getConfiguration().orientation
+                == Configuration.ORIENTATION_LANDSCAPE;
+        if (avoidAllInLandscape) {
+            // The phone's physical top and bottom become the short left and
+            // right edges in landscape and reverse-landscape orientations.
+            safeInsets = Insets.of(Math.max(cutout.left, roundedCornerLeft), 0,
+                Math.max(cutout.right, roundedCornerRight), 0);
+        } else {
+            safeInsets = Insets.of(cutout.left, Math.max(cutout.top, roundedCornerTop),
+                cutout.right, Math.max(cutout.bottom, roundedCornerBottom));
+        }
+
+        if (mRoot.getPaddingLeft() != safeInsets.left || mRoot.getPaddingTop() != safeInsets.top
+                || mRoot.getPaddingRight() != safeInsets.right
+                || mRoot.getPaddingBottom() != safeInsets.bottom) {
+            mRoot.setPadding(safeInsets.left, safeInsets.top, safeInsets.right, safeInsets.bottom);
+        }
     }
 
     private void setupCursorHiding() {
@@ -352,6 +423,15 @@ public class MainActivity extends Activity
     @Override
     protected void onResume() {
         super.onResume();
+
+        String displayCutoutMode = DisplayCutoutMode.get(
+            getSharedPreferences(PREFS_NAME, MODE_PRIVATE));
+        if (!mDisplayCutoutMode.equals(displayCutoutMode)) {
+            // Display safe-area changes invalidate Surface and inset dimensions; rebuild the
+            // activity before restarting the native consumer, as Termux:X11 does.
+            recreate();
+            return;
+        }
 
         applyScreenOrientation();
 

--- a/app/src/main/java/com/anland/termux/SettingsActivity.java
+++ b/app/src/main/java/com/anland/termux/SettingsActivity.java
@@ -288,6 +288,7 @@ public class SettingsActivity extends Activity {
         LinearLayout root = newPage(R.string.section_display);
         addResolutionSection(root);
         addScreenOrientationSection(root);
+        addDisplayCutoutSection(root);
         setContent(root);
     }
 
@@ -920,6 +921,42 @@ public class SettingsActivity extends Activity {
         hint.setTextColor(Color.GRAY);
         hint.setPadding(0, dp(4), 0, 0);
         root.addView(hint);
+    }
+
+    private void addDisplayCutoutSection(LinearLayout root) {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+
+        TextView label = new TextView(this);
+        label.setText(R.string.display_cutout_mode_label);
+        label.setTextSize(16);
+        label.setPadding(0, dp(24), 0, dp(8));
+        root.addView(label);
+
+        Spinner modeSpinner = new Spinner(this);
+        modeSpinner.setAdapter(new ArrayAdapter<>(this,
+            android.R.layout.simple_spinner_dropdown_item,
+            getResources().getStringArray(R.array.display_cutout_mode_labels)));
+
+        String current = DisplayCutoutMode.get(prefs);
+        int selected = 0;
+        for (int i = 0; i < DisplayCutoutMode.VALUES.length; i++) {
+            if (DisplayCutoutMode.VALUES[i].equals(current)) {
+                selected = i;
+                break;
+            }
+        }
+        modeSpinner.setSelection(selected);
+        modeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                prefs.edit().putString(DisplayCutoutMode.KEY,
+                    DisplayCutoutMode.VALUES[position]).apply();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {}
+        });
+        root.addView(modeSpinner);
     }
 
     // Maps a res_preset_labels index to {width, height}, or null for the index-0

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,7 +21,7 @@
     <string name="cat_touchpad_title">觸控板與滑鼠</string>
     <string name="cat_touchpad_subtitle">觸控板模式、指標擷取與靈敏度</string>
     <string name="cat_connection_subtitle">socket、root、麥克風、相機與音訊延遲</string>
-    <string name="cat_display_subtitle">解析度與螢幕方向</string>
+    <string name="cat_display_subtitle">解析度、螢幕方向與螢幕缺角</string>
     <string name="cat_general_title">一般</string>
     <string name="cat_general_subtitle">設定通知</string>
 
@@ -84,6 +84,7 @@
     <string name="resolution_hint">選擇預設或手動輸入數值。填 0 表示原生解析度。\"Screen ×\" 會依本裝置面板（橫向）縮放。下次連線時生效。</string>
 
     <string name="screen_orientation_hint">控制桌面檢視的螢幕方向。返回桌面時生效。</string>
+    <string name="display_cutout_mode_label">螢幕缺角處理</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">顯示設定通知</string>
@@ -144,6 +145,13 @@
         <item>橫向</item>
         <item>反向直向</item>
         <item>反向橫向</item>
+    </string-array>
+
+    <string-array name="display_cutout_mode_labels">
+        <item>畫面延伸到全部缺角區域</item>
+        <item>畫面僅延伸到 R 角區域</item>
+        <item>畫面僅延伸到瀏海/挖孔區域</item>
+        <item>畫面避開全部缺角區域</item>
     </string-array>
 
     <string-array name="captured_pointer_transform_labels">

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -21,7 +21,7 @@
     <string name="cat_touchpad_title">触摸板与鼠标</string>
     <string name="cat_touchpad_subtitle">触摸板模式、指针捕获与灵敏度</string>
     <string name="cat_connection_subtitle">套接字、root、麦克风、摄像头与音频延迟</string>
-    <string name="cat_display_subtitle">分辨率与屏幕方向</string>
+    <string name="cat_display_subtitle">分辨率、屏幕方向与屏幕缺角</string>
     <string name="cat_general_title">通用</string>
     <string name="cat_general_subtitle">设置通知</string>
 
@@ -84,6 +84,7 @@
     <string name="resolution_hint">选择预设或手动输入数值。填 0 表示原生分辨率。\"Screen ×\" 会按本设备面板（横向）缩放。下次连接时生效。</string>
 
     <string name="screen_orientation_hint">控制桌面视图的屏幕方向。返回桌面时生效。</string>
+    <string name="display_cutout_mode_label">屏幕缺角处理</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">显示设置通知</string>
@@ -144,6 +145,13 @@
         <item>横屏</item>
         <item>反向竖屏</item>
         <item>反向横屏</item>
+    </string-array>
+
+    <string-array name="display_cutout_mode_labels">
+        <item>画面延伸到全部缺角区域</item>
+        <item>画面仅延伸到R角区域</item>
+        <item>画面仅延伸到刘海/挖孔区域</item>
+        <item>画面避开全部缺角区域</item>
     </string-array>
 
     <string-array name="captured_pointer_transform_labels">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="cat_touchpad_title">Touchpad &amp; Mouse</string>
     <string name="cat_touchpad_subtitle">Touchpad mode, pointer capture &amp; sensitivity</string>
     <string name="cat_connection_subtitle">Socket, root, mic, camera &amp; audio latency</string>
-    <string name="cat_display_subtitle">Resolution &amp; screen orientation</string>
+    <string name="cat_display_subtitle">Resolution, screen orientation &amp; display cutout</string>
     <string name="cat_general_title">General</string>
     <string name="cat_general_subtitle">Settings notification</string>
 
@@ -84,6 +84,7 @@
     <string name="resolution_hint">Pick a preset or enter values manually. Leave 0 for native resolution. \"Screen ×\" scales this device\'s panel (landscape). Takes effect on next connect.</string>
 
     <string name="screen_orientation_hint">Controls the desktop view orientation. Takes effect when you return to the desktop.</string>
+    <string name="display_cutout_mode_label">Display cutout handling</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">Show settings notification</string>
@@ -144,6 +145,13 @@
         <item>Landscape</item>
         <item>Reverse portrait</item>
         <item>Reverse landscape</item>
+    </string-array>
+
+    <string-array name="display_cutout_mode_labels">
+        <item>Draw under all cutouts</item>
+        <item>Draw under rounded corners only</item>
+        <item>Draw under notch/punch hole only</item>
+        <item>Avoid all cutouts</item>
     </string-array>
 
     <string-array name="captured_pointer_transform_labels">


### PR DESCRIPTION
- Add four modes for hiding all cutouts, rounded corners only, notch or punch hole only, or none
- Default to hiding all cutouts and migrate legacy boolean preferences
- Apply black safe areas using display cutout insets and rounded corner radii
- Preserve safe layout behavior under Android 15 edge-to-edge enforcement
- Recreate the activity when the selected mode changes
- Add English, Simplified Chinese, and Traditional Chinese translations

---

| Option | Explanation |
|---|---|
| Draw under all cutouts | Extends the desktop into both rounded-corner and notch/punch-hole areas. |
| Draw under rounded corners only | Extends the desktop into rounded-corner areas while avoiding the notch/punch-hole area. |
| Draw under notch/punch hole only | Extends the desktop into the notch/punch-hole area while keeping rounded-corner safe areas. |
| Avoid all cutouts | Keeps the desktop within the safe area, avoiding both rounded corners and the notch/punch hole. |
