### PR TITLE
app: add picture-in-picture mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,9 @@
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden"
             android:enableOnBackInvokedCallback="false"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:resizeableActivity="true"
+            android:supportsPictureInPicture="true">
             <property
                 android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
                 android:value="true" />
@@ -32,7 +34,11 @@
         <activity
             android:name=".SettingsActivity"
             android:enableOnBackInvokedCallback="false"
+            android:excludeFromRecents="true"
             android:exported="true"
+            android:resizeableActivity="true"
+            android:supportsPictureInPicture="false"
+            android:taskAffinity=".SettingsActivity"
             android:theme="@android:style/Theme.DeviceDefault.Light.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/anland/termux/MainActivity.java
+++ b/app/src/main/java/com/anland/termux/MainActivity.java
@@ -2,10 +2,12 @@ package com.anland.termux;
 
 import android.Manifest;
 import android.app.Activity;
+import android.app.AppOpsManager;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.app.PictureInPictureParams;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
@@ -78,6 +80,7 @@ public class MainActivity extends Activity
     // Persistent "tap to open Settings" notification, toggleable in Settings > General.
     private static final String KEY_NOTIFICATION_ENABLED = "settings_notification";
     private static final String KEY_SCREEN_ORIENTATION = "screen_orientation";
+    private static final String KEY_PIP_MODE = "pip_mode";
     private static final String KEY_POINTER_CAPTURE = "pointer_capture";
     private static final String KEY_TRANSFORM_CAPTURED_POINTER = "transform_captured_pointer";
     private static final String KEY_CAPTURED_POINTER_SPEED_FACTOR = "captured_pointer_speed_factor";
@@ -96,6 +99,8 @@ public class MainActivity extends Activity
     private boolean mPointerPositionKnown = false;
     private final float[] mTransformedPointerDelta = new float[2];
     private String mDisplayCutoutMode = DisplayCutoutMode.HIDE_ALL;
+    private boolean mPipTransitionPending = false;
+    private boolean mVirtualKeyboardVisibleBeforePip = false;
     // Layout JSON the current bar was built from; used to detect edits on resume.
     private String mAppliedLayoutJson = "";
 
@@ -423,6 +428,7 @@ public class MainActivity extends Activity
     @Override
     protected void onResume() {
         super.onResume();
+        mPipTransitionPending = false;
 
         String displayCutoutMode = DisplayCutoutMode.get(
             getSharedPreferences(PREFS_NAME, MODE_PRIVATE));
@@ -534,11 +540,55 @@ public class MainActivity extends Activity
         DisplayManager dm = getSystemService(DisplayManager.class);
         if (dm != null)
             dm.unregisterDisplayListener(displayListener);
-        Native.nativeStop();
+        if (!mPipTransitionPending && !isInPictureInPictureMode())
+            Native.nativeStop();
+    }
+
+    private boolean hasPipPermission() {
+        AppOpsManager appOps = getSystemService(AppOpsManager.class);
+        return appOps != null && appOps.unsafeCheckOpNoThrow(
+            AppOpsManager.OPSTR_PICTURE_IN_PICTURE,
+            android.os.Process.myUid(), getPackageName()) == AppOpsManager.MODE_ALLOWED;
+    }
+
+    @Override
+    protected void onUserLeaveHint() {
+        super.onUserLeaveHint();
+        boolean pipEnabled = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
+            .getBoolean(KEY_PIP_MODE, false);
+        if (pipEnabled
+                && getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+                && hasPipPermission()) {
+            PictureInPictureParams params = new PictureInPictureParams.Builder().build();
+            mPipTransitionPending = enterPictureInPictureMode(params);
+        }
+    }
+
+    @Override
+    public void onPictureInPictureModeChanged(boolean isInPictureInPictureMode,
+            Configuration newConfig) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig);
+        mPipTransitionPending = false;
+
+        if (isInPictureInPictureMode) {
+            setExtraKeysBarVisible(false);
+            mVirtualKeyboardVisibleBeforePip = virtualKeyboardView != null
+                && virtualKeyboardView.getVisibility() == View.VISIBLE;
+            if (mVirtualKeyboardVisibleBeforePip)
+                virtualKeyboardView.setVisibility(View.GONE);
+        } else {
+            setExtraKeysBarVisible(shouldShowBar(systemIme.isImeVisible()));
+            if (mVirtualKeyboardVisibleBeforePip && virtualKeyboardView != null) {
+                virtualKeyboardView.setVisibility(View.VISIBLE);
+                virtualKeyboardView.post(this::positionVirtualKeyboard);
+            }
+            mVirtualKeyboardVisibleBeforePip = false;
+        }
     }
 
     @Override
     protected void onDestroy() {
+        Native.nativeStop();
         NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         if (nm != null) nm.cancel(NOTIFICATION_ID);
         if (cameraInited) {

--- a/app/src/main/java/com/anland/termux/SettingsActivity.java
+++ b/app/src/main/java/com/anland/termux/SettingsActivity.java
@@ -56,6 +56,7 @@ public class SettingsActivity extends Activity {
     private static final String KEY_KEYBOARD_FLOATING = "keyboard_floating";
     private static final String KEY_NOTIFICATION_ENABLED = "settings_notification";
     private static final String KEY_SCREEN_ORIENTATION = "screen_orientation";
+    private static final String KEY_PIP_MODE = "pip_mode";
     private static final String DEFAULT_SOCKET_PATH = "/data/data/com.termux/files/usr/tmp/anland/display_daemon.sock";
     private static final int UNBOUND = -1;
 
@@ -289,6 +290,7 @@ public class SettingsActivity extends Activity {
         addResolutionSection(root);
         addScreenOrientationSection(root);
         addDisplayCutoutSection(root);
+        addPipSection(root);
         setContent(root);
     }
 
@@ -957,6 +959,26 @@ public class SettingsActivity extends Activity {
             public void onNothingSelected(AdapterView<?> parent) {}
         });
         root.addView(modeSpinner);
+    }
+
+    private void addPipSection(LinearLayout root) {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+
+        Switch pipSwitch = new Switch(this);
+        pipSwitch.setText(R.string.pip_mode_switch);
+        pipSwitch.setTextSize(14);
+        pipSwitch.setPadding(0, dp(24), 0, 0);
+        pipSwitch.setChecked(prefs.getBoolean(KEY_PIP_MODE, false));
+        pipSwitch.setOnCheckedChangeListener((v, checked) ->
+            prefs.edit().putBoolean(KEY_PIP_MODE, checked).apply());
+        root.addView(pipSwitch);
+
+        TextView hint = new TextView(this);
+        hint.setText(R.string.pip_mode_hint);
+        hint.setTextSize(12);
+        hint.setTextColor(Color.GRAY);
+        hint.setPadding(0, dp(4), 0, 0);
+        root.addView(hint);
     }
 
     // Maps a res_preset_labels index to {width, height}, or null for the index-0

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,7 +21,7 @@
     <string name="cat_touchpad_title">觸控板與滑鼠</string>
     <string name="cat_touchpad_subtitle">觸控板模式、指標擷取與靈敏度</string>
     <string name="cat_connection_subtitle">socket、root、麥克風、相機與音訊延遲</string>
-    <string name="cat_display_subtitle">解析度、螢幕方向與螢幕缺角</string>
+    <string name="cat_display_subtitle">解析度、螢幕方向、螢幕缺角與子母畫面</string>
     <string name="cat_general_title">一般</string>
     <string name="cat_general_subtitle">設定通知</string>
 
@@ -85,6 +85,8 @@
 
     <string name="screen_orientation_hint">控制桌面檢視的螢幕方向。返回桌面時生效。</string>
     <string name="display_cutout_mode_label">螢幕缺角處理</string>
+    <string name="pip_mode_switch">子母畫面模式</string>
+    <string name="pip_mode_hint">按下主畫面鍵或最近使用的應用程式鍵時，以子母畫面模式顯示應用程式。</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">顯示設定通知</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -21,7 +21,7 @@
     <string name="cat_touchpad_title">触摸板与鼠标</string>
     <string name="cat_touchpad_subtitle">触摸板模式、指针捕获与灵敏度</string>
     <string name="cat_connection_subtitle">套接字、root、麦克风、摄像头与音频延迟</string>
-    <string name="cat_display_subtitle">分辨率、屏幕方向与屏幕缺角</string>
+    <string name="cat_display_subtitle">分辨率、屏幕方向、屏幕缺角与画中画</string>
     <string name="cat_general_title">通用</string>
     <string name="cat_general_subtitle">设置通知</string>
 
@@ -85,6 +85,8 @@
 
     <string name="screen_orientation_hint">控制桌面视图的屏幕方向。返回桌面时生效。</string>
     <string name="display_cutout_mode_label">屏幕缺角处理</string>
+    <string name="pip_mode_switch">画中画模式</string>
+    <string name="pip_mode_hint">按下主屏幕键或最近任务键时，以画中画模式显示应用。</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">显示设置通知</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="cat_touchpad_title">Touchpad &amp; Mouse</string>
     <string name="cat_touchpad_subtitle">Touchpad mode, pointer capture &amp; sensitivity</string>
     <string name="cat_connection_subtitle">Socket, root, mic, camera &amp; audio latency</string>
-    <string name="cat_display_subtitle">Resolution, screen orientation &amp; display cutout</string>
+    <string name="cat_display_subtitle">Resolution, screen orientation, display cutout &amp; PIP</string>
     <string name="cat_general_title">General</string>
     <string name="cat_general_subtitle">Settings notification</string>
 
@@ -85,6 +85,8 @@
 
     <string name="screen_orientation_hint">Controls the desktop view orientation. Takes effect when you return to the desktop.</string>
     <string name="display_cutout_mode_label">Display cutout handling</string>
+    <string name="pip_mode_switch">PIP mode</string>
+    <string name="pip_mode_hint">Show the app in picture-in-picture mode when the Home or Recents button is pressed.</string>
 
     <!-- Settings notification -->
     <string name="notification_switch">Show settings notification</string>


### PR DESCRIPTION
- Add a Display setting to enable PIP mode
- Enter picture-in-picture when Home or Recents is pressed
- Keep the native display consumer running while in PIP
- Hide interactive overlays in the PIP window and restore them on exit
- Enable PIP support for the main activity
- Add English, Simplified Chinese, and Traditional Chinese translations