### PR TITLE
app: backport some commits from upstream 5.16-5.18

### DIFF
--- a/app/src/main/java/com/anland/termux/MainActivity.java
+++ b/app/src/main/java/com/anland/termux/MainActivity.java
@@ -19,6 +19,7 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.util.SparseArray;
 import android.view.Display;
 import android.view.Gravity;
 import android.view.InputDevice;
@@ -103,6 +104,15 @@ public class MainActivity extends Activity
     private float mPointerY = 0f;
     private boolean mPointerPositionKnown = false;
     private final float[] mTransformedPointerDelta = new float[2];
+    private Touchpad mCapturedTouchpad;
+    private int mCapturedTouchpadDeviceId = -1;
+    private boolean mCapturedTouchpadBaselineValid = false;
+    private int mCapturedTouchpadBaselinePointers = 0;
+    private float mCapturedTouchpadLastCentroidX = 0f;
+    private float mCapturedTouchpadLastCentroidY = 0f;
+    private final float[] mCapturedTouchpadResolvedDelta = new float[2];
+    private final SparseArray<Float> mButtonDragLastX = new SparseArray<>();
+    private final SparseArray<Float> mButtonDragLastY = new SparseArray<>();
     private String mDisplayCutoutMode = DisplayCutoutMode.HIDE_ALL;
     private boolean mPipTransitionPending = false;
     private boolean mVirtualKeyboardVisibleBeforePip = false;
@@ -194,12 +204,27 @@ public class MainActivity extends Activity
         getWindow().setDecorFitsSystemWindows(false);
 
         surfaceView = new SurfaceView(this);
+        surfaceView.setFocusable(true);
         surfaceView.setFocusableInTouchMode(true);
-        surfaceView.setOnCapturedPointerListener((v, event) ->
-            handleCapturedPointerEvent(event));
         systemIme = new SystemIME(this, this);
 
-        FrameLayout root = new FrameLayout(this);
+        FrameLayout root = new FrameLayout(this) {
+            @Override
+            public boolean dispatchCapturedPointerEvent(MotionEvent event) {
+                if (handleCapturedPointerEvent(event))
+                    return true;
+                return super.dispatchCapturedPointerEvent(event);
+            }
+
+            @Override
+            public void dispatchPointerCaptureChanged(boolean hasCapture) {
+                super.dispatchPointerCaptureChanged(hasCapture);
+                if (!hasCapture) {
+                    releaseAllMouseButtons();
+                    resetCapturedTouchpadGesture();
+                }
+            }
+        };
         root.setBackgroundColor(Color.BLACK);
         root.addView(surfaceView, new FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
@@ -212,6 +237,7 @@ public class MainActivity extends Activity
         // count / height) comes from the user's JSON config; see buildExtraKeysBar.
         mRoot = root;
         mDensity = getResources().getDisplayMetrics().density;
+        mCapturedTouchpad = new Touchpad(this, new CapturedTouchpadOutput(), false);
         mKeyboardFloating = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
             .getBoolean(KEY_KEYBOARD_FLOATING, true);
         buildExtraKeysBar();
@@ -655,6 +681,8 @@ public class MainActivity extends Activity
         super.onPause();
         if (surfaceView.hasPointerCapture())
             surfaceView.releasePointerCapture();
+        releaseAllMouseButtons();
+        resetCapturedTouchpadGesture();
         NotificationManager nm = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         if (nm != null) nm.cancel(NOTIFICATION_ID);
         DisplayManager dm = getSystemService(DisplayManager.class);
@@ -823,6 +851,8 @@ public class MainActivity extends Activity
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
         surfaceReady = false;
+        releaseAllMouseButtons();
+        resetCapturedTouchpadGesture();
         Native.nativeStop();
     }
 
@@ -1262,53 +1292,423 @@ public class MainActivity extends Activity
             surfaceView.releasePointerCapture();
     }
 
+    private final class CapturedTouchpadOutput implements Touchpad.Output {
+        @Override
+        public void onMotion(float dx, float dy) {
+            // Raw relative axes drive the cursor so motion is not applied twice.
+        }
+
+        @Override
+        public void onScroll(int axis, float value) {
+            Native.nativeSendMouseScroll(axis, value);
+        }
+
+        @Override
+        public void onButton(int button, boolean pressed) {
+            Native.nativeSendMouseButton(button, pressed);
+        }
+
+        @Override
+        public void onTouch(int action, int pointerId, float x, float y) {
+            Native.nativeSendTouch(action,
+                x * capturedPointerScaleX(), y * capturedPointerScaleY(), pointerId);
+        }
+
+        @Override
+        public void onTouchFrame() {
+            Native.nativeSendTouchFrame();
+        }
+
+        @Override
+        public float cursorX() {
+            ensureCapturedPointerPosition();
+            return mPointerX / capturedPointerScaleX();
+        }
+
+        @Override
+        public float cursorY() {
+            ensureCapturedPointerPosition();
+            return mPointerY / capturedPointerScaleY();
+        }
+    }
+
+    /** Handle relative mice and hardware touchpads delivered through pointer capture. */
     private boolean handleCapturedPointerEvent(MotionEvent event) {
+        boolean isTouchpad = event.isFromSource(InputDevice.SOURCE_TOUCHPAD);
+        boolean isRelativeMouse = !isTouchpad
+            && event.isFromSource(InputDevice.SOURCE_MOUSE_RELATIVE);
+        if (!isTouchpad && !isRelativeMouse)
+            return false;
+
+        if (isTouchpad)
+            return handleCapturedTouchpadEvent(event);
+
         int action = event.getActionMasked();
-        if (action == MotionEvent.ACTION_SCROLL) {
-            float vScroll = event.getAxisValue(MotionEvent.AXIS_VSCROLL);
-            float hScroll = event.getAxisValue(MotionEvent.AXIS_HSCROLL);
-            if (vScroll != 0)
-                Native.nativeSendMouseScroll(0, -vScroll * 10);
-            if (hScroll != 0)
-                Native.nativeSendMouseScroll(1, hScroll * 10);
-        } else if (action == MotionEvent.ACTION_MOVE && event.getPointerCount() == 1) {
-            InputDevice device = event.getDevice();
-            boolean hasRelativeAxes = device != null
-                && device.getMotionRange(MotionEvent.AXIS_RELATIVE_X) != null;
-            boolean isRelativeMouse = (event.getSource() & InputDevice.SOURCE_MOUSE_RELATIVE)
-                == InputDevice.SOURCE_MOUSE_RELATIVE;
+        if (action == MotionEvent.ACTION_MOVE || action == MotionEvent.ACTION_HOVER_MOVE) {
+            for (int i = 0; i < event.getHistorySize(); i++)
+                processCapturedRelativeMouseSample(event, i);
+            processCapturedRelativeMouseSample(event, -1);
+        } else if (action == MotionEvent.ACTION_SCROLL) {
+            for (int i = 0; i < event.getHistorySize(); i++)
+                sendCapturedScrollAxes(event, i);
+            sendCapturedScrollAxes(event, -1);
+        }
 
-            if (hasRelativeAxes || isRelativeMouse) {
-                float dx = hasRelativeAxes
-                    ? event.getAxisValue(MotionEvent.AXIS_RELATIVE_X) : event.getX();
-                float dy = hasRelativeAxes
-                    ? event.getAxisValue(MotionEvent.AXIS_RELATIVE_Y) : event.getY();
-                transformCapturedPointerDelta(dx, dy, event.getSource());
+        if (action == MotionEvent.ACTION_CANCEL)
+            releaseAllMouseButtons();
+        else
+            updateMouseButtonStateFromEvent(event);
+        return true;
+    }
 
-                float scaleX = (customScreenWidth > 0 && viewWidth > 0)
-                    ? (float) customScreenWidth / viewWidth : 1f;
-                float scaleY = (customScreenHeight > 0 && viewHeight > 0)
-                    ? (float) customScreenHeight / viewHeight : 1f;
-                dx = mTransformedPointerDelta[0]
-                    * mCapturedPointerSpeedFactor * mDensity * scaleX;
-                dy = mTransformedPointerDelta[1]
-                    * mCapturedPointerSpeedFactor * mDensity * scaleY;
+    private void processCapturedRelativeMouseSample(MotionEvent event, int historyPos) {
+        InputDevice device = event.getDevice();
+        boolean hasRelativeX = device != null
+            && device.getMotionRange(MotionEvent.AXIS_RELATIVE_X) != null;
+        boolean hasRelativeY = device != null
+            && device.getMotionRange(MotionEvent.AXIS_RELATIVE_Y) != null;
+        float dx = hasRelativeX
+            ? capturedAxis(event, MotionEvent.AXIS_RELATIVE_X, 0, historyPos)
+            : capturedCoordinate(event, true, 0, historyPos);
+        float dy = hasRelativeY
+            ? capturedAxis(event, MotionEvent.AXIS_RELATIVE_Y, 0, historyPos)
+            : capturedCoordinate(event, false, 0, historyPos);
+        moveCapturedPointerBy(dx, dy, event.getSource());
+    }
 
-                int outputWidth = customScreenWidth > 0 ? customScreenWidth : viewWidth;
-                int outputHeight = customScreenHeight > 0 ? customScreenHeight : viewHeight;
-                if (!mPointerPositionKnown) {
-                    mPointerX = Math.max(0, outputWidth) / 2f;
-                    mPointerY = Math.max(0, outputHeight) / 2f;
-                    mPointerPositionKnown = true;
-                }
-                mPointerX = clamp(mPointerX + dx, 0f, Math.max(0, outputWidth));
-                mPointerY = clamp(mPointerY + dy, 0f, Math.max(0, outputHeight));
-                Native.nativeSendMouseMotion(mPointerX, mPointerY, dx, dy);
+    private boolean handleCapturedTouchpadEvent(MotionEvent event) {
+        int action = event.getActionMasked();
+        int pointerCount = event.getPointerCount();
+        boolean hasButton = event.getButtonState() != 0
+            || action == MotionEvent.ACTION_BUTTON_PRESS
+            || action == MotionEvent.ACTION_BUTTON_RELEASE;
+        boolean canceled = action == MotionEvent.ACTION_CANCEL
+            || ((action == MotionEvent.ACTION_POINTER_UP || action == MotionEvent.ACTION_UP)
+                && (event.getFlags() & MotionEvent.FLAG_CANCELED) != 0);
+        boolean explicitScroll = (action == MotionEvent.ACTION_MOVE
+            || action == MotionEvent.ACTION_HOVER_MOVE)
+            && hasCapturedTouchpadScrollAxes(event);
+        boolean scrollEvent = action == MotionEvent.ACTION_SCROLL || explicitScroll;
+        boolean leftOrRightHeld = (effectiveButtonState(event)
+            & (MotionEvent.BUTTON_PRIMARY | MotionEvent.BUTTON_SECONDARY)) != 0;
+
+        if (!leftOrRightHeld) {
+            mButtonDragLastX.clear();
+            mButtonDragLastY.clear();
+        }
+
+        if (canceled) {
+            mCapturedTouchpad.cancel();
+            mCapturedTouchpadBaselineValid = false;
+        } else if (scrollEvent) {
+            mCapturedTouchpad.cancel();
+            for (int i = 0; i < event.getHistorySize(); i++)
+                sendCapturedScrollAxes(event, i);
+            sendCapturedScrollAxes(event, -1);
+            mCapturedTouchpadBaselineValid = false;
+        } else if (hasButton) {
+            mCapturedTouchpad.cancel();
+        } else {
+            updateCapturedTouchpadBounds(event);
+            mCapturedTouchpad.onTouch(event);
+        }
+
+        if (!canceled && !scrollEvent && !mCapturedTouchpad.isForwardingTouch()) {
+            switch (action) {
+                case MotionEvent.ACTION_DOWN:
+                    setCapturedTouchpadBaseline(event, -1);
+                    mButtonDragLastX.clear();
+                    mButtonDragLastY.clear();
+                    break;
+                case MotionEvent.ACTION_POINTER_DOWN:
+                case MotionEvent.ACTION_POINTER_UP:
+                    mCapturedTouchpadBaselineValid = false;
+                    mButtonDragLastX.clear();
+                    mButtonDragLastY.clear();
+                    break;
+                case MotionEvent.ACTION_MOVE:
+                case MotionEvent.ACTION_HOVER_MOVE:
+                    if (pointerCount == 1) {
+                        for (int i = 0; i < event.getHistorySize(); i++)
+                            processCapturedTouchpadMotionSample(event, i);
+                        processCapturedTouchpadMotionSample(event, -1);
+                    } else if (leftOrRightHeld) {
+                        processCapturedTouchpadButtonDrag(event);
+                    }
+                    break;
+                case MotionEvent.ACTION_UP:
+                    mCapturedTouchpadBaselineValid = false;
+                    mButtonDragLastX.clear();
+                    mButtonDragLastY.clear();
+                    break;
+                default:
+                    break;
             }
         }
 
-        updateMouseButtons(event);
+        if (action == MotionEvent.ACTION_CANCEL)
+            releaseAllMouseButtons();
+        else
+            updateMouseButtonStateFromEvent(event);
         return true;
+    }
+
+    private void processCapturedTouchpadMotionSample(MotionEvent event, int historyPos) {
+        if (event.getPointerCount() != 1)
+            return;
+        float dx = capturedAxis(event, MotionEvent.AXIS_RELATIVE_X, 0, historyPos);
+        float dy = capturedAxis(event, MotionEvent.AXIS_RELATIVE_Y, 0, historyPos);
+        float[] resolved = applyCapturedTouchpadAbsoluteFallback(
+            event, historyPos, dx, dy);
+        moveCapturedPointerBy(resolved[0], resolved[1], event.getSource());
+    }
+
+    private void processCapturedTouchpadButtonDrag(MotionEvent event) {
+        int pointerCount = event.getPointerCount();
+        if (pointerCount < 2)
+            return;
+        float scaleX = capturedTouchpadCoordinateScale(
+            event, MotionEvent.AXIS_X, true);
+        float scaleY = capturedTouchpadCoordinateScale(
+            event, MotionEvent.AXIS_Y, false);
+
+        for (int i = mButtonDragLastX.size() - 1; i >= 0; i--) {
+            int id = mButtonDragLastX.keyAt(i);
+            if (event.findPointerIndex(id) < 0) {
+                mButtonDragLastX.removeAt(i);
+                mButtonDragLastY.delete(id);
+            }
+        }
+
+        float bestDx = 0f;
+        float bestDy = 0f;
+        float bestMagnitude = -1f;
+        for (int i = 0; i < pointerCount; i++) {
+            int id = event.getPointerId(i);
+            float lastX = mButtonDragLastX.get(id, Float.NaN);
+            float lastY = mButtonDragLastY.get(id, Float.NaN);
+            if (Float.isNaN(lastX) || Float.isNaN(lastY))
+                continue;
+            float dx = (event.getX(i) - lastX) * scaleX;
+            float dy = (event.getY(i) - lastY) * scaleY;
+            float magnitude = dx * dx + dy * dy;
+            if (magnitude > bestMagnitude) {
+                bestMagnitude = magnitude;
+                bestDx = dx;
+                bestDy = dy;
+            }
+        }
+
+        for (int i = 0; i < pointerCount; i++) {
+            int id = event.getPointerId(i);
+            mButtonDragLastX.put(id, event.getX(i));
+            mButtonDragLastY.put(id, event.getY(i));
+        }
+
+        if (bestMagnitude > 0f)
+            moveCapturedPointerBy(bestDx, bestDy, event.getSource());
+    }
+
+    private void updateCapturedTouchpadBounds(MotionEvent event) {
+        int width = capturedPointerViewWidth();
+        int height = capturedPointerViewHeight();
+        mCapturedTouchpad.setOutputSize(width, height);
+        if (event.getDeviceId() == mCapturedTouchpadDeviceId)
+            return;
+        InputDevice.MotionRange xRange = capturedPadRange(event, MotionEvent.AXIS_X);
+        InputDevice.MotionRange yRange = capturedPadRange(event, MotionEvent.AXIS_Y);
+        if (xRange == null || yRange == null
+                || xRange.getRange() <= 0f || yRange.getRange() <= 0f)
+            return;
+        mCapturedTouchpadDeviceId = event.getDeviceId();
+        mCapturedTouchpad.setInputBounds(xRange.getMin(), yRange.getMin(),
+            xRange.getRange(), yRange.getRange());
+    }
+
+    private InputDevice.MotionRange capturedPadRange(MotionEvent event, int axis) {
+        InputDevice device = event.getDevice();
+        if (device == null)
+            return null;
+        InputDevice.MotionRange range =
+            device.getMotionRange(axis, InputDevice.SOURCE_TOUCHPAD);
+        return range != null ? range : device.getMotionRange(axis);
+    }
+
+    private float[] applyCapturedTouchpadAbsoluteFallback(
+            MotionEvent event, int historyPos, float dx, float dy) {
+        int pointerCount = event.getPointerCount();
+        float centroidX = capturedTouchpadCentroid(event, historyPos, true);
+        float centroidY = capturedTouchpadCentroid(event, historyPos, false);
+        if (dx == 0f && dy == 0f
+                && mCapturedTouchpadBaselineValid
+                && mCapturedTouchpadBaselinePointers == pointerCount) {
+            dx = (centroidX - mCapturedTouchpadLastCentroidX)
+                * capturedTouchpadCoordinateScale(event, MotionEvent.AXIS_X, true);
+            dy = (centroidY - mCapturedTouchpadLastCentroidY)
+                * capturedTouchpadCoordinateScale(event, MotionEvent.AXIS_Y, false);
+        }
+        mCapturedTouchpadLastCentroidX = centroidX;
+        mCapturedTouchpadLastCentroidY = centroidY;
+        mCapturedTouchpadBaselinePointers = pointerCount;
+        mCapturedTouchpadBaselineValid = true;
+        mCapturedTouchpadResolvedDelta[0] = dx;
+        mCapturedTouchpadResolvedDelta[1] = dy;
+        return mCapturedTouchpadResolvedDelta;
+    }
+
+    private float capturedTouchpadCoordinateScale(
+            MotionEvent event, int axis, boolean xAxis) {
+        InputDevice.MotionRange range = capturedPadRange(event, axis);
+        float span = range == null ? 0f : range.getRange();
+        int size = xAxis ? capturedPointerViewWidth() : capturedPointerViewHeight();
+        return span > 0f && size > 0 ? size / span : 0f;
+    }
+
+    private void sendCapturedScrollAxes(MotionEvent event, int historyPos) {
+        if (event.getPointerCount() <= 0)
+            return;
+        float vScroll = capturedAxis(
+            event, MotionEvent.AXIS_VSCROLL, 0, historyPos);
+        float hScroll = capturedAxis(
+            event, MotionEvent.AXIS_HSCROLL, 0, historyPos);
+        if (vScroll != 0f || hScroll != 0f) {
+            if (vScroll != 0f)
+                Native.nativeSendMouseScroll(0, -vScroll * 10f);
+            if (hScroll != 0f)
+                Native.nativeSendMouseScroll(1, hScroll * 10f);
+            return;
+        }
+
+        float gestureX = capturedAxis(event,
+            MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE, 0, historyPos);
+        float gestureY = capturedAxis(event,
+            MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE, 0, historyPos);
+        if (gestureY != 0f)
+            Native.nativeSendMouseScroll(0, gestureY);
+        if (gestureX != 0f)
+            Native.nativeSendMouseScroll(1, -gestureX);
+    }
+
+    private boolean hasCapturedTouchpadScrollAxes(MotionEvent event) {
+        if (event.getPointerCount() <= 0)
+            return false;
+        for (int i = 0; i < event.getHistorySize(); i++) {
+            if (hasCapturedScrollAxesAt(event, i))
+                return true;
+        }
+        return hasCapturedScrollAxesAt(event, -1);
+    }
+
+    private boolean hasCapturedScrollAxesAt(MotionEvent event, int historyPos) {
+        return capturedAxis(event, MotionEvent.AXIS_VSCROLL, 0, historyPos) != 0f
+            || capturedAxis(event, MotionEvent.AXIS_HSCROLL, 0, historyPos) != 0f
+            || capturedAxis(event, MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE,
+                0, historyPos) != 0f
+            || capturedAxis(event, MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE,
+                0, historyPos) != 0f;
+    }
+
+    private float capturedAxis(
+            MotionEvent event, int axis, int pointerIndex, int historyPos) {
+        return historyPos >= 0
+            ? event.getHistoricalAxisValue(axis, pointerIndex, historyPos)
+            : event.getAxisValue(axis, pointerIndex);
+    }
+
+    private float capturedCoordinate(
+            MotionEvent event, boolean xAxis, int pointerIndex, int historyPos) {
+        if (historyPos >= 0) {
+            return xAxis
+                ? event.getHistoricalX(pointerIndex, historyPos)
+                : event.getHistoricalY(pointerIndex, historyPos);
+        }
+        return xAxis ? event.getX(pointerIndex) : event.getY(pointerIndex);
+    }
+
+    private float capturedTouchpadCentroid(
+            MotionEvent event, int historyPos, boolean xAxis) {
+        int pointerCount = event.getPointerCount();
+        if (pointerCount <= 0)
+            return 0f;
+        float total = 0f;
+        for (int i = 0; i < pointerCount; i++)
+            total += capturedCoordinate(event, xAxis, i, historyPos);
+        return total / pointerCount;
+    }
+
+    private void setCapturedTouchpadBaseline(MotionEvent event, int historyPos) {
+        mCapturedTouchpadLastCentroidX =
+            capturedTouchpadCentroid(event, historyPos, true);
+        mCapturedTouchpadLastCentroidY =
+            capturedTouchpadCentroid(event, historyPos, false);
+        mCapturedTouchpadBaselinePointers = event.getPointerCount();
+        mCapturedTouchpadBaselineValid = mCapturedTouchpadBaselinePointers > 0;
+    }
+
+    private void resetCapturedTouchpadGesture() {
+        if (mCapturedTouchpad != null)
+            mCapturedTouchpad.cancel();
+        mCapturedTouchpadDeviceId = -1;
+        mCapturedTouchpadBaselineValid = false;
+        mCapturedTouchpadBaselinePointers = 0;
+        mCapturedTouchpadLastCentroidX = 0f;
+        mCapturedTouchpadLastCentroidY = 0f;
+        mButtonDragLastX.clear();
+        mButtonDragLastY.clear();
+    }
+
+    private int capturedPointerViewWidth() {
+        return viewWidth > 0 ? viewWidth : surfaceView.getWidth();
+    }
+
+    private int capturedPointerViewHeight() {
+        return viewHeight > 0 ? viewHeight : surfaceView.getHeight();
+    }
+
+    private float capturedPointerScaleX() {
+        int width = capturedPointerViewWidth();
+        return customScreenWidth > 0 && width > 0
+            ? (float) customScreenWidth / width : 1f;
+    }
+
+    private float capturedPointerScaleY() {
+        int height = capturedPointerViewHeight();
+        return customScreenHeight > 0 && height > 0
+            ? (float) customScreenHeight / height : 1f;
+    }
+
+    private void ensureCapturedPointerPosition() {
+        int outputWidth = customScreenWidth > 0
+            ? customScreenWidth : capturedPointerViewWidth();
+        int outputHeight = customScreenHeight > 0
+            ? customScreenHeight : capturedPointerViewHeight();
+        if (!mPointerPositionKnown) {
+            mPointerX = Math.max(0, outputWidth) / 2f;
+            mPointerY = Math.max(0, outputHeight) / 2f;
+            mPointerPositionKnown = true;
+        }
+        mPointerX = clamp(mPointerX, 0f, Math.max(0, outputWidth));
+        mPointerY = clamp(mPointerY, 0f, Math.max(0, outputHeight));
+    }
+
+    private void moveCapturedPointerBy(float dx, float dy, int source) {
+        if (!Float.isFinite(dx) || !Float.isFinite(dy)
+                || (dx == 0f && dy == 0f))
+            return;
+        transformCapturedPointerDelta(dx, dy, source);
+        dx = mTransformedPointerDelta[0]
+            * mCapturedPointerSpeedFactor * mDensity * capturedPointerScaleX();
+        dy = mTransformedPointerDelta[1]
+            * mCapturedPointerSpeedFactor * mDensity * capturedPointerScaleY();
+
+        ensureCapturedPointerPosition();
+        int outputWidth = customScreenWidth > 0
+            ? customScreenWidth : capturedPointerViewWidth();
+        int outputHeight = customScreenHeight > 0
+            ? customScreenHeight : capturedPointerViewHeight();
+        mPointerX = clamp(mPointerX + dx, 0f, Math.max(0, outputWidth));
+        mPointerY = clamp(mPointerY + dy, 0f, Math.max(0, outputHeight));
+        Native.nativeSendMouseMotion(mPointerX, mPointerY, dx, dy);
     }
 
     private void transformCapturedPointerDelta(float x, float y, int source) {
@@ -1353,9 +1753,7 @@ public class MainActivity extends Activity
         mTransformedPointerDelta[1] = y;
     }
 
-    private void updateMouseButtons(MotionEvent event) {
-
-        int currentBS = event.getButtonState();
+    private void updateMouseButtonState(int currentBS) {
         for (int[] btn : BUTTON_MAP) {
             boolean wasDown = (savedBS & btn[0]) != 0;
             boolean isDown  = (currentBS & btn[0]) != 0;
@@ -1363,6 +1761,37 @@ public class MainActivity extends Activity
                 Native.nativeSendMouseButton(btn[1], isDown);
         }
         savedBS = currentBS;
+    }
+
+    private static int effectiveButtonState(MotionEvent event) {
+        int buttonState = event.getButtonState();
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_BUTTON_PRESS)
+            buttonState |= event.getActionButton();
+        else if (action == MotionEvent.ACTION_BUTTON_RELEASE)
+            buttonState &= ~event.getActionButton();
+        return buttonState;
+    }
+
+    private void updateMouseButtonStateFromEvent(MotionEvent event) {
+        updateMouseButtonState(effectiveButtonState(event));
+    }
+
+    private void updateMouseButtons(MotionEvent event) {
+        if (event.getActionMasked() == MotionEvent.ACTION_CANCEL)
+            releaseAllMouseButtons();
+        else
+            updateMouseButtonStateFromEvent(event);
+    }
+
+    private void releaseAllMouseButtons() {
+        if (savedBS == 0)
+            return;
+        for (int[] btn : BUTTON_MAP) {
+            if ((savedBS & btn[0]) != 0)
+                Native.nativeSendMouseButton(btn[1], false);
+        }
+        savedBS = 0;
     }
 
     private static float clamp(float value, float min, float max) {

--- a/app/src/main/java/com/anland/termux/MainActivity.java
+++ b/app/src/main/java/com/anland/termux/MainActivity.java
@@ -90,6 +90,11 @@ public class MainActivity extends Activity
     private static final String KEY_POINTER_CAPTURE = "pointer_capture";
     private static final String KEY_TRANSFORM_CAPTURED_POINTER = "transform_captured_pointer";
     private static final String KEY_CAPTURED_POINTER_SPEED_FACTOR = "captured_pointer_speed_factor";
+    private static final String KEY_SCROLL_SPEED = "scroll_speed";
+    private static final String KEY_SCROLL_REVERSE = "scroll_reverse";
+    private static final String KEY_SCROLL_THRESHOLD = "touchpad_scroll_threshold";
+    private static final String KEY_MOVE_THRESHOLD = "touchpad_move_threshold";
+    private static final String KEY_GESTURE_SCALE = "touchpad_gesture_scale";
     // System soft-keyboard bridge: hidden input, text forwarding and toggle.
     private SystemIME systemIme;
     private int mImeBottom = 0;   // last IME bottom inset
@@ -1287,6 +1292,17 @@ public class MainActivity extends Activity
             mCapturedPointerTransform = "no";
         int speedPercent = prefs.getInt(KEY_CAPTURED_POINTER_SPEED_FACTOR, 100);
         mCapturedPointerSpeedFactor = Math.max(1, Math.min(300, speedPercent)) / 100f;
+        mCapturedTouchpad.setScrollSpeed(prefs.getFloat(
+            KEY_SCROLL_SPEED, Touchpad.DEFAULT_SCROLL_SPEED));
+        mCapturedTouchpad.setScrollReversed(
+            prefs.getBoolean(KEY_SCROLL_REVERSE, false));
+        mCapturedTouchpad.setGestureThresholds(
+            prefs.getFloat(KEY_SCROLL_THRESHOLD,
+                Touchpad.DEFAULT_SCROLL_THRESHOLD_FACTOR),
+            prefs.getFloat(KEY_MOVE_THRESHOLD,
+                Touchpad.DEFAULT_MOVE_THRESHOLD_FACTOR));
+        mCapturedTouchpad.setGestureScale(prefs.getFloat(
+            KEY_GESTURE_SCALE, Touchpad.DEFAULT_GESTURE_SCALE));
 
         if (!mPointerCaptureEnabled && surfaceView.hasPointerCapture())
             surfaceView.releasePointerCapture();

--- a/app/src/main/java/com/anland/termux/MainActivity.java
+++ b/app/src/main/java/com/anland/termux/MainActivity.java
@@ -72,6 +72,8 @@ public class MainActivity extends Activity
     private static final String KEY_EXTRA_KEYS_ENABLED = "extra_keys_bar";
     private static final String KEY_AUTO_SHOW_EXTRA_KEYS = "auto_show_extra_keys";
     private static final String KEY_EXTRA_KEYS_LAYOUT = "extra_keys_layout";
+    // Linux input-event-codes.h: KEY_BACK (the browser-back key).
+    private static final int EVDEV_BROWSER_BACK = 158;
     // When on, the IME and extra-keys bar float over the display instead of
     // shrinking it: the bar rides up with the keyboard but the surface keeps
     // its full size. See relayout() and buildExtraKeysBar().
@@ -1059,6 +1061,16 @@ public class MainActivity extends Activity
     // Called from KeyInterceptor (accessibility service) to handle keys that
     // the normal onKeyDown/onKeyUp might miss (e.g. Fn combos).
     public boolean handleAccessibilityKey(KeyEvent event) {
+        // Some tablet keyboard layouts expose their physical Esc key as
+        // Android Back (Linux KEY_BACK / Browser Back). Convert it only on
+        // the accessibility-interception path so the normal Android Back and
+        // configured user-action behaviour is unchanged when interception is off.
+        if (shouldConvertBackToEscape(event)) {
+            if (event.getRepeatCount() > 0)
+                return true;
+            return forwardKeyToLinux(event, true);
+        }
+
         Boolean actionHandled = handleConfiguredUserAction(event);
         if (actionHandled != null)
             return actionHandled;
@@ -1066,19 +1078,26 @@ public class MainActivity extends Activity
         if (event.getRepeatCount() > 0)
             return true;
 
-        boolean handled = forwardKeyToLinux(event);
+        boolean handled = forwardKeyToLinux(event, true);
         releasePointerCaptureOnEscape(event);
         return handled;
     }
 
     private boolean forwardKeyToLinux(KeyEvent event) {
+        return forwardKeyToLinux(event, false);
+    }
+
+    private boolean forwardKeyToLinux(KeyEvent event, boolean convertBackToEscape) {
         int keyCode = event.getKeyCode();
         int action = event.getAction() == KeyEvent.ACTION_DOWN ? 0 : 1;
         int evdev = -1;
 
+        if (convertBackToEscape && shouldConvertBackToEscape(event))
+            evdev = KeyCodeMapper.getScanCode(KeyEvent.KEYCODE_ESCAPE);
+
         // Reserved Android keys may carry vendor scan codes that Linux does not
         // recognize, so prefer their explicit evdev mapping.
-        if (shouldPreferMappedKey(keyCode))
+        if (evdev == -1 && shouldPreferMappedKey(keyCode))
             evdev = KeyCodeMapper.getScanCode(keyCode);
 
         if (evdev == -1 && event.getScanCode() != 0)
@@ -1092,6 +1111,11 @@ public class MainActivity extends Activity
 
         Native.nativeSendKey(action, evdev);
         return true;
+    }
+
+    private static boolean shouldConvertBackToEscape(KeyEvent event) {
+        return event.getKeyCode() == KeyEvent.KEYCODE_BACK
+                || event.getScanCode() == EVDEV_BROWSER_BACK;
     }
 
     private static boolean shouldPreferMappedKey(int keyCode) {

--- a/app/src/main/java/com/anland/termux/SettingsActivity.java
+++ b/app/src/main/java/com/anland/termux/SettingsActivity.java
@@ -69,6 +69,11 @@ public class SettingsActivity extends Activity {
     private static final String KEY_POINTER_CAPTURE = "pointer_capture";
     private static final String KEY_TRANSFORM_CAPTURED_POINTER = "transform_captured_pointer";
     private static final String KEY_CAPTURED_POINTER_SPEED_FACTOR = "captured_pointer_speed_factor";
+    private static final String KEY_SCROLL_SPEED = "scroll_speed";
+    private static final String KEY_SCROLL_REVERSE = "scroll_reverse";
+    private static final String KEY_SCROLL_THRESHOLD = "touchpad_scroll_threshold";
+    private static final String KEY_MOVE_THRESHOLD = "touchpad_move_threshold";
+    private static final String KEY_GESTURE_SCALE = "touchpad_gesture_scale";
     private static final String[] CAPTURED_POINTER_TRANSFORMS = {
         "no", "c", "cc", "ud", "at"
     };
@@ -671,6 +676,7 @@ public class SettingsActivity extends Activity {
         root.addView(accelLayout);
 
         buildPointerCaptureSection(root, prefs);
+        buildHardwareTouchpadTuningSection(root, prefs);
     }
 
     private void buildPointerCaptureSection(LinearLayout root, SharedPreferences prefs) {
@@ -761,6 +767,92 @@ public class SettingsActivity extends Activity {
             transformSpinner.setEnabled(checked);
             speedSeek.setEnabled(checked);
         });
+    }
+
+    private void buildHardwareTouchpadTuningSection(
+            LinearLayout root, SharedPreferences prefs) {
+        Switch reverseScrollSwitch = new Switch(this);
+        reverseScrollSwitch.setText(R.string.scroll_reverse_switch);
+        reverseScrollSwitch.setTextSize(14);
+        reverseScrollSwitch.setPadding(0, dp(8), 0, 0);
+        reverseScrollSwitch.setChecked(prefs.getBoolean(KEY_SCROLL_REVERSE, false));
+        reverseScrollSwitch.setOnCheckedChangeListener((v, checked) ->
+            prefs.edit().putBoolean(KEY_SCROLL_REVERSE, checked).apply());
+        root.addView(reverseScrollSwitch);
+
+        TextView reverseScrollHint = new TextView(this);
+        reverseScrollHint.setText(R.string.scroll_reverse_hint);
+        reverseScrollHint.setTextSize(12);
+        reverseScrollHint.setTextColor(getColor(R.color.settings_text_secondary));
+        reverseScrollHint.setPadding(0, dp(4), 0, dp(12));
+        root.addView(reverseScrollHint);
+
+        addFloatSlider(root, R.string.scroll_speed_label, R.string.scroll_speed_value,
+            null, KEY_SCROLL_SPEED, 0.05f, 3.0f, 0.05f,
+            Touchpad.DEFAULT_SCROLL_SPEED);
+        addFloatSlider(root, R.string.scroll_threshold_label,
+            R.string.threshold_factor_value, R.string.scroll_threshold_hint,
+            KEY_SCROLL_THRESHOLD, 0.05f, 3.0f, 0.05f,
+            Touchpad.DEFAULT_SCROLL_THRESHOLD_FACTOR);
+        addFloatSlider(root, R.string.move_threshold_label,
+            R.string.threshold_factor_value, R.string.move_threshold_hint,
+            KEY_MOVE_THRESHOLD, 0.1f, 8.0f, 0.05f,
+            Touchpad.DEFAULT_MOVE_THRESHOLD_FACTOR);
+        addFloatSlider(root, R.string.gesture_scale_label,
+            R.string.gesture_scale_value, R.string.gesture_scale_hint,
+            KEY_GESTURE_SCALE, 100f, 3000f, 20f,
+            Touchpad.DEFAULT_GESTURE_SCALE);
+    }
+
+    private void addFloatSlider(LinearLayout root, int labelRes, int valueFormatRes,
+            Integer hintRes, final String key, final float min, float max,
+            final float step, float defaultValue) {
+        SharedPreferences prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
+
+        LinearLayout layout = new LinearLayout(this);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(0, dp(8), 0, hintRes == null ? dp(16) : 0);
+
+        TextView label = new TextView(this);
+        label.setText(labelRes);
+        label.setTextSize(14);
+        layout.addView(label);
+
+        TextView value = new TextView(this);
+        value.setTextSize(14);
+        value.setTextColor(getColor(R.color.settings_accent));
+        layout.addView(value);
+
+        SeekBar seek = new SeekBar(this);
+        seek.setMax(Math.round((max - min) / step));
+        float current = Math.max(min,
+            Math.min(max, prefs.getFloat(key, defaultValue)));
+        seek.setProgress(Math.round((current - min) / step));
+        value.setText(getString(valueFormatRes, current));
+        seek.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(
+                    SeekBar seekBar, int progress, boolean fromUser) {
+                float selected = min + progress * step;
+                value.setText(getString(valueFormatRes, selected));
+                if (fromUser)
+                    prefs.edit().putFloat(key, selected).apply();
+            }
+
+            @Override public void onStartTrackingTouch(SeekBar seekBar) {}
+            @Override public void onStopTrackingTouch(SeekBar seekBar) {}
+        });
+        layout.addView(seek);
+        root.addView(layout);
+
+        if (hintRes != null) {
+            TextView hint = new TextView(this);
+            hint.setText(hintRes);
+            hint.setTextSize(12);
+            hint.setTextColor(getColor(R.color.settings_text_secondary));
+            hint.setPadding(0, dp(2), 0, dp(12));
+            root.addView(hint);
+        }
     }
 
     // Connection settings: a custom daemon socket path and a "connect with root"

--- a/app/src/main/java/com/anland/termux/Touchpad.java
+++ b/app/src/main/java/com/anland/termux/Touchpad.java
@@ -1,0 +1,793 @@
+package com.anland.termux;
+
+import android.content.Context;
+import android.graphics.Matrix;
+import android.view.InputDevice;
+import android.view.MotionEvent;
+import android.view.ViewConfiguration;
+
+/**
+ * Laptop-style touchpad: interprets finger contacts as relative cursor motion,
+ * taps/clicks, long-press drag and two-finger scroll.
+ *
+ * The input is a captured hardware touchpad's own coordinate range, described
+ * by {@link #setInputBounds}.
+ *
+ * Only three gestures are implemented: one finger moves the cursor, two fingers
+ * travelling together scroll, and a quick two-finger tap is a right click.
+ * Anything else — a pinch, three or more fingers — is forwarded as touch, mapped
+ * into a square around the cursor (see {@link #setGestureScale}).
+ *
+ * The cursor itself belongs to the host: this class only reports deltas through
+ * {@link Output#onMotion} and reads the current position back through
+ * {@link Output#cursorX}/{@link Output#cursorY}, so both instances share one
+ * pointer.
+ */
+public final class Touchpad {
+
+    /** Touch actions used by {@link Output#onTouch}, matching the wire protocol. */
+    static final int TOUCH_DOWN = 0;
+    static final int TOUCH_UP = 1;
+    static final int TOUCH_MOVE = 2;
+
+    /** Everything this class produces, and the cursor position it needs back. */
+    interface Output {
+        void onMotion(float dx, float dy);
+        void onScroll(int axis, float value);
+        void onButton(int button, boolean pressed);
+        /** One contact of a gesture forwarded as touch, in output coordinates. */
+        void onTouch(int action, int pointerId, float x, float y);
+        /** End of a batch of {@link #onTouch} calls. */
+        void onTouchFrame();
+        float cursorX();
+        float cursorY();
+    }
+
+    // 状态机
+    private static final int STATE_IDLE = 0;
+    private static final int STATE_ONE_FINGER = 1;
+    private static final int STATE_TWO_FINGER = 2;
+    private static final int STATE_DRAGGING = 3;
+    private int currentState = STATE_IDLE;
+
+    private float lastX1, lastY1;
+    private float startX1, startY1;
+    private float lastX2, lastY2;
+    private long downTime1;
+    private final float touchSlop;
+
+    private boolean isSingleTapCandidate = false;
+    private boolean isTwoFingerTapCandidate = false;
+    private boolean isDraggingActive = false;
+
+    private long lastTapTime = 0;
+    private float lastTapX, lastTapY;
+    private boolean isDoubleTapPending = false;
+
+    private static final long TOUCH_LONG_PRESS_TIMEOUT = 500;
+    private boolean hasLongPressed = false;
+    private boolean isLongPressPossible = false;
+    private boolean isMultiFinger = false;
+
+    // Two-finger classification, decided once per two-finger phase so a gesture
+    // cannot oscillate between scrolling and being declined.
+    private static final int TWO_FINGER_UNDECIDED = 0;
+    private static final int TWO_FINGER_SCROLL = 1;
+    private static final int TWO_FINGER_NOT_SCROLL = 2;
+    private int twoFingerMode = TWO_FINGER_UNDECIDED;
+    // Both fingers' positions when the two-finger phase began. The scroll test
+    // measures displacement from here rather than frame to frame, matching AOSP.
+    private float twoFingerStartX1, twoFingerStartY1;
+    private float twoFingerStartX2, twoFingerStartY2;
+
+    // Latched for the rest of the gesture once the recognizer declines it, so the
+    // whole remaining stream (including the final UP) reaches the forwarding path
+    // and the touches it emitted are released.
+    private boolean gestureUnhandled = false;
+
+    // AOSP's equivalents are 1.5mm and 7.0mm ("Two Finger Scroll/Move Distance
+    // Thresh" in libgestures). Coordinates here are output pixels rather than
+    // millimetres, so the physical values do not carry over; these are multiples of
+    // touchSlop instead. Defaults keep AOSP's ~4.7:1 ratio.
+    static final float DEFAULT_SCROLL_THRESHOLD_FACTOR = 0.5f;
+    static final float DEFAULT_MOVE_THRESHOLD_FACTOR = 2.35f;
+    private float scrollDistanceThreshold;
+    private float moveDistanceThreshold;
+
+    // Which axis a two-finger scroll is reported on: an axis wins when it exceeds
+    // this fraction of the other, so a diagonal drag can report both.
+    private static final float AXIS_DOMINANCE_RATIO = 0.5f;
+    /** Scroll distance per pixel of finger travel. */
+    static final float DEFAULT_SCROLL_SPEED = 0.5f;
+    private float scrollSpeed = DEFAULT_SCROLL_SPEED;
+    private boolean scrollReversed = false;
+
+    // The input coordinate space: where this device's contacts live. A zero range
+    // means "not known yet", which leaves coordinates untouched.
+    private float inputMinX = 0f;
+    private float inputMinY = 0f;
+    private float inputRangeX = 0f;
+    private float inputRangeY = 0f;
+    // The output coordinate space, i.e. the view the gestures act on.
+    private int outputWidth = 0;
+    private int outputHeight = 0;
+
+    /** Side of the square, in output pixels, a forwarded gesture is mapped into. */
+    static final float DEFAULT_GESTURE_SCALE = 800f;
+    private float gestureScale = DEFAULT_GESTURE_SCALE;
+
+    private float mouseAccelStrength = 1.0f; // 加速度强度，0.5 ~ 10.0
+
+    // ===== 调整后的平滑/抗抖动参数（更灵敏、更连续） =====
+    private static final float DEAD_ZONE = 0.3f;          // 死区从 0.5 降到 0.3
+    private static final float SMOOTHING_FACTOR = 0.45f;   // 提高响应速度
+    private static final float ACCUMULATED_THRESHOLD = 0.1f; // 从 0.8 大幅降低，让移动更连续
+
+    private float smoothedDx = 0f;
+    private float smoothedDy = 0f;
+    private float accumulatedX = 0f;
+    private float accumulatedY = 0f;
+    private boolean smoothInitialized = false;
+
+    // Contacts currently held down on the remote for a declined gesture, with the
+    // last position each was sent at so they can be released without an event.
+    private static final int MAX_FORWARDED = 10;
+    private final int[] forwardedIds = new int[MAX_FORWARDED];
+    private final float[] forwardedX = new float[MAX_FORWARDED];
+    private final float[] forwardedY = new float[MAX_FORWARDED];
+    private int forwardedCount = 0;
+
+    private final Matrix normalizeTransform = new Matrix();
+    private float gestureFactor = 1f;
+    private float gestureOffsetX = 0f;
+    private float gestureOffsetY = 0f;
+    private final float[] mappedPoint = new float[2];
+
+    private final Output output;
+    // Captured hardware taps already arrive as separate clicks, so callers can
+    // disable the synthetic double-click pair.
+    private final boolean synthesizeDoubleTap;
+
+    Touchpad(Context context, Output output, boolean synthesizeDoubleTap) {
+        this.output = output;
+        this.synthesizeDoubleTap = synthesizeDoubleTap;
+        touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+        setGestureThresholds(DEFAULT_SCROLL_THRESHOLD_FACTOR,
+                DEFAULT_MOVE_THRESHOLD_FACTOR);
+    }
+
+    /**
+     * Describe the coordinate space this instance's events arrive in: the view size
+     * using the hardware touchpad's motion ranges.
+     */
+    void setInputBounds(float minX, float minY, float rangeX, float rangeY) {
+        inputMinX = minX;
+        inputMinY = minY;
+        inputRangeX = Math.max(0f, rangeX);
+        inputRangeY = Math.max(0f, rangeY);
+    }
+
+    /** Set the view size gestures are interpreted and forwarded in. */
+    void setOutputSize(int width, int height) {
+        if (width == outputWidth && height == outputHeight)
+            return;
+        outputWidth = width;
+        outputHeight = height;
+        resetSmoothing();
+    }
+
+    /**
+     * Set the side, in output pixels, of the square a forwarded gesture is mapped
+     * into. This is the gesture's magnitude: the whole input area spans this many
+     * pixels, so a larger value makes the same finger movement travel further.
+     */
+    void setGestureScale(float scale) {
+        gestureScale = Math.max(50f, Math.min(4000f, scale));
+    }
+
+    /** Set the acceleration strength (clamped to 0.5 ~ 10.0). */
+    void setAccelStrength(float strength) {
+        mouseAccelStrength = Math.max(0.5f, Math.min(10.0f, strength));
+    }
+
+    /** Set the two-finger scroll distance per pixel of travel (0.05 ~ 5.0). */
+    void setScrollSpeed(float speed) {
+        scrollSpeed = Math.max(0.05f, Math.min(5.0f, speed));
+    }
+
+    /** Invert both scroll axes ("natural" scrolling). */
+    void setScrollReversed(boolean reversed) {
+        scrollReversed = reversed;
+    }
+
+    /**
+     * Set the two-finger classification thresholds, as multiples of touchSlop.
+     *
+     * scrollFactor is how far a finger must travel before it counts as moving at all;
+     * lower it if a pinch is being mistaken for a scroll. moveFactor is how far the
+     * leading finger must travel before an ambiguous phase is resolved; lower it if
+     * scrolling feels slow to engage.
+     */
+    void setGestureThresholds(float scrollFactor, float moveFactor) {
+        scrollDistanceThreshold = touchSlop * Math.max(0.05f, Math.min(5.0f, scrollFactor));
+        moveDistanceThreshold = touchSlop * Math.max(0.1f, Math.min(10.0f, moveFactor));
+    }
+
+    /** True while a declined gesture is being forwarded as touch. */
+    boolean isForwardingTouch() {
+        return forwardedCount > 0;
+    }
+
+    /** Cancel an in-progress gesture, e.g. when the capture window loses focus. */
+    void cancel() {
+        releaseForwardedTouches();
+        if (isDraggingActive)
+            sendButton(0x110, false);
+        resetTouchpadState();
+        resetSmoothing();
+        lastTapTime = 0L;
+        lastTapX = 0f;
+        lastTapY = 0f;
+    }
+
+    /**
+     * Interpret one event from this device.
+     *
+     * Events belonging to a gesture this class does not implement are forwarded as
+     * touch instead, so nothing is silently dropped.
+     */
+    void onTouch(MotionEvent event) {
+        MotionEvent normalized = normalizeToOutput(event);
+        boolean handled;
+        try {
+            handled = recognize(normalized != null ? normalized : event);
+        } finally {
+            if (normalized != null)
+                normalized.recycle();
+        }
+        if (!handled)
+            forwardAsTouch(event);
+    }
+
+    /**
+     * Scale contacts from the input space into output pixels, which is what the
+     * touchSlop-based thresholds are calibrated against.
+     *
+     * Returns null when the two spaces already coincide, so no copy is made.
+     * SOURCE_CLASS_POSITION ignores MotionEvent
+     * transforms on newer Android releases, hence the temporary touchscreen source.
+     */
+    private MotionEvent normalizeToOutput(MotionEvent event) {
+        if (inputRangeX <= 0f || inputRangeY <= 0f
+                || outputWidth <= 0 || outputHeight <= 0)
+            return null;
+        float sx = outputWidth / inputRangeX;
+        float sy = outputHeight / inputRangeY;
+        if (sx == 1f && sy == 1f && inputMinX == 0f && inputMinY == 0f)
+            return null;
+
+        MotionEvent copy = MotionEvent.obtain(event);
+        copy.setSource(InputDevice.SOURCE_TOUCHSCREEN);
+        normalizeTransform.setScale(sx, sy);
+        normalizeTransform.postTranslate(-inputMinX * sx, -inputMinY * sy);
+        copy.transform(normalizeTransform);
+        return copy;
+    }
+
+    /** Larger of the two by magnitude, keeping its sign (libgestures MaxMag). */
+    private static float maxMag(float a, float b) {
+        return Math.abs(a) > Math.abs(b) ? a : b;
+    }
+
+    /** Smaller of the two by magnitude, keeping its sign (libgestures MinMag). */
+    private static float minMag(float a, float b) {
+        return Math.abs(a) < Math.abs(b) ? a : b;
+    }
+
+    /**
+     * Classify a two-finger phase, following the rule AOSP's touchpad gesture
+     * library uses (libgestures ImmediateInterpreter::GetTwoFingerGestureType):
+     * take each finger's displacement since the phase began, pick whichever axis
+     * dominates, and require both fingers to have travelled the same way along it.
+     *
+     * A pinch moves the fingers in opposite directions, so the sign product is
+     * negative and it is not a scroll. One finger resting while the other travels
+     * zeroes the small term, which also fails the test — AOSP calls that a cursor
+     * move; here everything that is not a scroll is forwarded as touch.
+     */
+    private int classifyTwoFinger(float x1, float y1, float x2, float y2) {
+        float dx1 = x1 - twoFingerStartX1;
+        float dy1 = y1 - twoFingerStartY1;
+        float dx2 = x2 - twoFingerStartX2;
+        float dy2 = y2 - twoFingerStartY2;
+
+        float largeDx = maxMag(dx1, dx2);
+        float largeDy = maxMag(dy1, dy2);
+        float large;
+        float small;
+        if (Math.abs(largeDx) > Math.abs(largeDy)) {
+            large = largeDx;
+            small = minMag(dx1, dx2);
+        } else {
+            large = largeDy;
+            small = minMag(dy1, dy2);
+        }
+        if (Math.abs(small) < scrollDistanceThreshold)
+            small = 0f;
+
+        if (large * small <= 0f) {
+            // Not the same direction: a pinch, or one finger resting while the other
+            // travels. Stay undecided until one finger has clearly committed, so a
+            // two-finger tap is still allowed to become a click.
+            return Math.abs(large) < moveDistanceThreshold
+                    ? TWO_FINGER_UNDECIDED : TWO_FINGER_NOT_SCROLL;
+        }
+        return Math.abs(large) < scrollDistanceThreshold
+                ? TWO_FINGER_UNDECIDED : TWO_FINGER_SCROLL;
+    }
+
+    /**
+     * Give up on the current gesture: release anything in progress and latch the
+     * unhandled flag so every remaining event is forwarded, including the final UP.
+     * The forwarding path needs that whole tail to release its touch points.
+     */
+    private boolean declineGesture() {
+        if (isDraggingActive)
+            sendButton(0x110, false);
+        isDraggingActive = false;
+        isSingleTapCandidate = false;
+        isTwoFingerTapCandidate = false;
+        isLongPressPossible = false;
+        gestureUnhandled = true;
+        resetSmoothing();
+        return false;
+    }
+
+    private void sendButton(int button, boolean pressed) {
+        if (output != null)
+            output.onButton(button, pressed);
+    }
+
+    private void sendScroll(int axis, float value) {
+        if (output != null)
+            output.onScroll(axis, value);
+    }
+
+    private void sendMotion(float dx, float dy) {
+        if (output != null)
+            output.onMotion(dx, dy);
+    }
+
+    // ==================== 触摸板手势及辅助方法 ====================
+    /**
+     * Run the gesture state machine over contacts already in output coordinates.
+     *
+     * @return true when this class consumed the event, false when the gesture is not
+     *         one it implements. A false result latches for the remainder of the
+     *         gesture, so the whole stream through the final UP is forwarded.
+     */
+    private boolean recognize(MotionEvent event) {
+        int action = event.getActionMasked();
+        int pointerCount = event.getPointerCount();
+
+        // Once declined, stay declined: the gesture is mid-way through being
+        // forwarded as touch and its pointer-up events still have to get there.
+        if (gestureUnhandled) {
+            if (action == MotionEvent.ACTION_UP
+                    || action == MotionEvent.ACTION_CANCEL) {
+                resetTouchpadState();
+                resetSmoothing();
+            }
+            return false;
+        }
+
+        switch (action) {
+            case MotionEvent.ACTION_DOWN: {
+                float x = event.getX();
+                float y = event.getY();
+                startX1 = lastX1 = x;
+                startY1 = lastY1 = y;
+                downTime1 = event.getEventTime();
+                hasLongPressed = false;
+                isLongPressPossible = true;
+                isSingleTapCandidate = true;
+                isTwoFingerTapCandidate = false;
+                isDraggingActive = false;
+                isMultiFinger = false;
+                currentState = STATE_ONE_FINGER;
+                twoFingerMode = TWO_FINGER_UNDECIDED;
+                resetSmoothing();
+                break;
+            }
+            case MotionEvent.ACTION_POINTER_DOWN: {
+                isMultiFinger = true;
+                isSingleTapCandidate = false;
+                isLongPressPossible = false;
+                if (currentState == STATE_DRAGGING) {
+                    sendButton(0x110, false);
+                    isDraggingActive = false;
+                }
+                if (pointerCount == 2) {
+                    currentState = STATE_TWO_FINGER;
+                    isTwoFingerTapCandidate = true;
+                    lastX1 = twoFingerStartX1 = event.getX(0);
+                    lastY1 = twoFingerStartY1 = event.getY(0);
+                    lastX2 = twoFingerStartX2 = event.getX(1);
+                    lastY2 = twoFingerStartY2 = event.getY(1);
+                    twoFingerMode = TWO_FINGER_UNDECIDED;
+                } else if (pointerCount >= 3) {
+                    // Three or more fingers is never one of ours.
+                    return declineGesture();
+                }
+                break;
+            }
+            case MotionEvent.ACTION_MOVE: {
+                if (pointerCount == 1 && !isMultiFinger) {
+                    float x = event.getX();
+                    float y = event.getY();
+                    float rawDx = x - lastX1;
+                    float rawDy = y - lastY1;
+                    float dist = (float) Math.hypot(x - startX1, y - startY1);
+
+                    if (dist > touchSlop) {
+                        isLongPressPossible = false;
+                        isSingleTapCandidate = false;
+                        // Cleared once the remaining finger actually moves, so a
+                        // scroll or drag whose second finger lifted early cannot
+                        // finish as a right-click.
+                        isTwoFingerTapCandidate = false;
+                    }
+
+                    if (isLongPressPossible && !hasLongPressed &&
+                            (event.getEventTime() - downTime1) >= TOUCH_LONG_PRESS_TIMEOUT) {
+                        hasLongPressed = true;
+                        currentState = STATE_DRAGGING;
+                        isDraggingActive = true;
+                        // No motion is emitted with the press: the cursor belongs to
+                        // the host and is already where the drag should start.
+                        sendButton(0x110, true);
+                        resetSmoothing();
+                        break;
+                    }
+
+                    float[] smoothed = applySmoothing(rawDx, rawDy);
+                    float smoothDx = smoothed[0];
+                    float smoothDy = smoothed[1];
+
+                    if (smoothDx != 0f || smoothDy != 0f) {
+                        // 计算移动距离（平滑后的欧式距离）
+                        float distance = (float) Math.hypot(smoothDx, smoothDy);
+
+                        // 改进的加速度曲线：以 10px 为参考阈值，使小位移也能获得明显加速
+                        float speedFactor = distance / 10.0f;
+                        // 使用 sigmoid-like 曲线：scale = 1 + (strength - 1) * (speed / (1 + speed))
+                        float dynamicScale = 1.0f + (mouseAccelStrength - 1.0f) * (speedFactor / (1.0f + speedFactor));
+                        // 限制范围，防止失控（最大不超过 10 倍）
+                        dynamicScale = Math.max(0.3f, Math.min(10.0f, dynamicScale));
+
+                        float moveX = smoothDx * dynamicScale;
+                        float moveY = smoothDy * dynamicScale;
+                        sendMotion(moveX, moveY);
+                    }
+
+                    lastX1 = x;
+                    lastY1 = y;
+
+                } else if (pointerCount == 2) {
+                    if (currentState == STATE_TWO_FINGER) {
+                        float x1 = event.getX(0);
+                        float y1 = event.getY(0);
+                        float x2 = event.getX(1);
+                        float y2 = event.getY(1);
+
+                        if (twoFingerMode == TWO_FINGER_UNDECIDED) {
+                            twoFingerMode = classifyTwoFinger(x1, y1, x2, y2);
+                            if (twoFingerMode == TWO_FINGER_NOT_SCROLL) {
+                                // A pinch, or one finger travelling against a resting
+                                // one. Hand the gesture to the forwarding path.
+                                return declineGesture();
+                            }
+                        }
+
+                        if (twoFingerMode == TWO_FINGER_SCROLL) {
+                            float avgDx = ((x1 - lastX1) + (x2 - lastX2)) / 2;
+                            float avgDy = ((y1 - lastY1) + (y2 - lastY2)) / 2;
+
+                            if (Math.abs(avgDx) > 1 || Math.abs(avgDy) > 1) {
+                                isTwoFingerTapCandidate = false;
+                                float scale = scrollReversed
+                                        ? -scrollSpeed : scrollSpeed;
+                                if (Math.abs(avgDy)
+                                        > Math.abs(avgDx) * AXIS_DOMINANCE_RATIO) {
+                                    sendScroll(0, -avgDy * scale);
+                                }
+                                if (Math.abs(avgDx)
+                                        > Math.abs(avgDy) * AXIS_DOMINANCE_RATIO) {
+                                    sendScroll(1, avgDx * scale);
+                                }
+                                lastX1 = x1;
+                                lastY1 = y1;
+                                lastX2 = x2;
+                                lastY2 = y2;
+                            }
+                        } else {
+                            // Still ambiguous, so emit nothing yet, but keep the
+                            // anchors current: the first scroll delta after the
+                            // decision must not be the whole accumulated drift.
+                            lastX1 = x1;
+                            lastY1 = y1;
+                            lastX2 = x2;
+                            lastY2 = y2;
+                        }
+                    }
+                }
+                break;
+            }
+            case MotionEvent.ACTION_POINTER_UP: {
+                int remaining = pointerCount - 1;
+                if (remaining == 1) {
+                    isMultiFinger = false;
+                    isSingleTapCandidate = false;
+                    isLongPressPossible = false;
+                    int idx = (event.getActionIndex() == 0) ? 1 : 0;
+                    lastX1 = event.getX(idx);
+                    lastY1 = event.getY(idx);
+                    startX1 = lastX1;
+                    startY1 = lastY1;
+                    downTime1 = event.getEventTime();
+                    hasLongPressed = false;
+                    currentState = STATE_ONE_FINGER;
+                    resetSmoothing();
+                }
+                break;
+            }
+            case MotionEvent.ACTION_UP: {
+                long duration = event.getEventTime() - downTime1;
+                boolean isQuickTap = duration < 300;
+
+                if (isDraggingActive) {
+                    sendButton(0x110, false);
+                    isDraggingActive = false;
+                    resetTouchpadState();
+                    resetSmoothing();
+                    return true;
+                }
+
+                if (isTwoFingerTapCandidate && isQuickTap) {
+                    sendButton(0x111, true);
+                    sendButton(0x111, false);
+                    resetTouchpadState();
+                    resetSmoothing();
+                    return true;
+                }
+
+                if (currentState == STATE_ONE_FINGER && isSingleTapCandidate && isQuickTap) {
+                    long gap = event.getEventTime() - lastTapTime;
+                    float dist = (float) Math.hypot(lastX1 - lastTapX, lastY1 - lastTapY);
+                    if (synthesizeDoubleTap && gap < 300 && dist < touchSlop
+                            && !isDoubleTapPending) {
+                        isDoubleTapPending = true;
+                        sendButton(0x110, true);
+                        sendButton(0x110, false);
+                        sendButton(0x110, true);
+                        sendButton(0x110, false);
+                        isDoubleTapPending = false;
+                        lastTapTime = 0;
+                    } else {
+                        sendButton(0x110, true);
+                        sendButton(0x110, false);
+                        lastTapTime = event.getEventTime();
+                        lastTapX = lastX1;
+                        lastTapY = lastY1;
+                        isDoubleTapPending = false;
+                    }
+                    resetTouchpadState();
+                    resetSmoothing();
+                    return true;
+                }
+                resetTouchpadState();
+                resetSmoothing();
+                break;
+            }
+            case MotionEvent.ACTION_CANCEL: {
+                if (isDraggingActive) {
+                    sendButton(0x110, false);
+                    isDraggingActive = false;
+                }
+                resetTouchpadState();
+                resetSmoothing();
+                break;
+            }
+        }
+        return true;
+    }
+
+    // ==================== 未处理手势 → 触摸转发 ====================
+    /**
+     * Forward a declined gesture (a pinch, or three or more fingers) as touch.
+     *
+     * Contacts are mapped into a square of {@link #gestureScale} output pixels
+     * centred on the cursor. Spreading the input area over the whole output would be
+     * wrong for a gesture: the input's aspect ratio is not the output's, so the
+     * gesture came out distorted, and it covered the entire output however small the
+     * real finger movement was. A square around the cursor puts the gesture where
+     * the user is looking and makes its magnitude one setting. The scale is uniform
+     * on both axes, so the input's own aspect ratio survives inside that square and
+     * a pinch behaves the same whichever way the fingers move.
+     */
+    private void forwardAsTouch(MotionEvent event) {
+        if (output == null)
+            return;
+        int action = event.getActionMasked();
+        if (action == MotionEvent.ACTION_CANCEL) {
+            releaseForwardedTouches();
+            return;
+        }
+        if (!computeGestureTransform())
+            return;
+
+        int upIndex = (action == MotionEvent.ACTION_UP
+                || action == MotionEvent.ACTION_POINTER_UP)
+                ? event.getActionIndex() : -1;
+        boolean sent = false;
+
+        for (int i = 0; i < event.getPointerCount(); i++) {
+            if (i == upIndex)
+                continue;
+            int id = event.getPointerId(i);
+            mapToCursorSquare(event.getX(i), event.getY(i));
+            int slot = forwardedSlot(id);
+            if (slot < 0) {
+                // Catch-up down. The fingers already on the device were read as
+                // cursor motion, or as a two-finger phase that had not been decided
+                // yet, so the remote has never seen them go down — and a compositor
+                // drops motion for a contact id it never saw, which would leave a
+                // pinch showing a single finger.
+                if (addForwarded(id, mappedPoint[0], mappedPoint[1])) {
+                    output.onTouch(TOUCH_DOWN, id, mappedPoint[0], mappedPoint[1]);
+                    sent = true;
+                }
+            } else if (action == MotionEvent.ACTION_MOVE) {
+                forwardedX[slot] = mappedPoint[0];
+                forwardedY[slot] = mappedPoint[1];
+                output.onTouch(TOUCH_MOVE, id, mappedPoint[0], mappedPoint[1]);
+                sent = true;
+            }
+        }
+
+        if (upIndex >= 0) {
+            int id = event.getPointerId(upIndex);
+            mapToCursorSquare(event.getX(upIndex), event.getY(upIndex));
+            if (removeForwarded(id)) {
+                output.onTouch(TOUCH_UP, id, mappedPoint[0], mappedPoint[1]);
+                sent = true;
+            }
+        }
+
+        if (sent)
+            output.onTouchFrame();
+    }
+
+    /**
+     * Release every contact still held down for a forwarded gesture. Needed when the
+     * gesture is cut short before its own UP arrives — a physical pad button, a
+     * cancelled stream, or lost capture — otherwise they stay down on the remote for
+     * good.
+     */
+    private void releaseForwardedTouches() {
+        if (forwardedCount == 0 || output == null)
+            return;
+        for (int i = 0; i < forwardedCount; i++)
+            output.onTouch(TOUCH_UP, forwardedIds[i], forwardedX[i], forwardedY[i]);
+        forwardedCount = 0;
+        output.onTouchFrame();
+    }
+
+    /** Centre the square on the cursor. False when there is nothing to map into. */
+    private boolean computeGestureTransform() {
+        if (inputRangeX <= 0f || inputRangeY <= 0f)
+            return false;
+        float cursorX = output.cursorX();
+        float cursorY = output.cursorY();
+        if (!Float.isFinite(cursorX) || !Float.isFinite(cursorY))
+            return false;
+        // The longer input axis spans the full square; the shorter keeps its ratio.
+        gestureFactor = gestureScale / Math.max(inputRangeX, inputRangeY);
+        gestureOffsetX = cursorX - (inputMinX + inputRangeX / 2f) * gestureFactor;
+        gestureOffsetY = cursorY - (inputMinY + inputRangeY / 2f) * gestureFactor;
+        return true;
+    }
+
+    private void mapToCursorSquare(float x, float y) {
+        mappedPoint[0] = x * gestureFactor + gestureOffsetX;
+        mappedPoint[1] = y * gestureFactor + gestureOffsetY;
+    }
+
+    private int forwardedSlot(int pointerId) {
+        for (int i = 0; i < forwardedCount; i++) {
+            if (forwardedIds[i] == pointerId)
+                return i;
+        }
+        return -1;
+    }
+
+    private boolean addForwarded(int pointerId, float x, float y) {
+        if (forwardedCount >= MAX_FORWARDED)
+            return false;
+        forwardedIds[forwardedCount] = pointerId;
+        forwardedX[forwardedCount] = x;
+        forwardedY[forwardedCount] = y;
+        forwardedCount++;
+        return true;
+    }
+
+    private boolean removeForwarded(int pointerId) {
+        int slot = forwardedSlot(pointerId);
+        if (slot < 0)
+            return false;
+        forwardedCount--;
+        for (int i = slot; i < forwardedCount; i++) {
+            forwardedIds[i] = forwardedIds[i + 1];
+            forwardedX[i] = forwardedX[i + 1];
+            forwardedY[i] = forwardedY[i + 1];
+        }
+        return true;
+    }
+
+    private void resetTouchpadState() {
+        currentState = STATE_IDLE;
+        isSingleTapCandidate = false;
+        isTwoFingerTapCandidate = false;
+        isDoubleTapPending = false;
+        hasLongPressed = false;
+        isDraggingActive = false;
+        isLongPressPossible = false;
+        isMultiFinger = false;
+        twoFingerMode = TWO_FINGER_UNDECIDED;
+        // Cleared here rather than in declineGesture: the latch has to outlive the
+        // events that follow it and only lifts when the gesture itself ends.
+        gestureUnhandled = false;
+    }
+
+    private void resetSmoothing() {
+        smoothedDx = 0f;
+        smoothedDy = 0f;
+        accumulatedX = 0f;
+        accumulatedY = 0f;
+        smoothInitialized = false;
+    }
+
+    private float[] applySmoothing(float rawDx, float rawDy) {
+        float deadDx = Math.abs(rawDx) < DEAD_ZONE ? 0f : rawDx;
+        float deadDy = Math.abs(rawDy) < DEAD_ZONE ? 0f : rawDy;
+
+        if (deadDx == 0f && deadDy == 0f) {
+            return new float[]{0f, 0f};
+        }
+
+        if (!smoothInitialized) {
+            smoothedDx = deadDx;
+            smoothedDy = deadDy;
+            smoothInitialized = true;
+        } else {
+            smoothedDx = SMOOTHING_FACTOR * deadDx + (1 - SMOOTHING_FACTOR) * smoothedDx;
+            smoothedDy = SMOOTHING_FACTOR * deadDy + (1 - SMOOTHING_FACTOR) * smoothedDy;
+        }
+
+        // 累积阈值大幅降低，让移动更加连续
+        accumulatedX += smoothedDx;
+        accumulatedY += smoothedDy;
+
+        float outX = 0f;
+        float outY = 0f;
+        if (Math.abs(accumulatedX) >= ACCUMULATED_THRESHOLD) {
+            outX = accumulatedX;
+            accumulatedX = 0f;
+        }
+        if (Math.abs(accumulatedY) >= ACCUMULATED_THRESHOLD) {
+            outY = accumulatedY;
+            accumulatedY = 0f;
+        }
+        return new float[]{outX, outY};
+    }
+}

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -63,6 +63,18 @@
     <string name="transform_captured_pointer_label">轉換擷取的指標移動</string>
     <string name="captured_pointer_speed_label">擷取的指標速度係數，%</string>
     <string name="captured_pointer_speed_value">%1$d%%</string>
+    <string name="scroll_reverse_switch">反轉擷取觸控板的捲動方向</string>
+    <string name="scroll_reverse_hint">開啟後內容會跟隨手指移動（「自然捲動」）。僅套用於已擷取硬體觸控板的雙指捲動。</string>
+    <string name="scroll_speed_label">雙指捲動速度</string>
+    <string name="scroll_speed_value">%1$.2f</string>
+    <string name="threshold_factor_value">%1$.2f 倍觸控閾值</string>
+    <string name="scroll_threshold_label">捲動判定閾值</string>
+    <string name="scroll_threshold_hint">手指必須移動多遠才視為開始移動。如果雙指縮放被判定為捲動，請降低此值。</string>
+    <string name="move_threshold_label">手勢判定閾值</string>
+    <string name="move_threshold_hint">主導手指必須移動多遠才會判定含糊的雙指手勢。如果捲動啟動遲滯，請降低此值。</string>
+    <string name="gesture_scale_label">手勢幅度</string>
+    <string name="gesture_scale_value">%1$.0f 像素</string>
+    <string name="gesture_scale_hint">轉為觸控的手勢（雙指縮放、三指及以上）會對應到以指標為中心、邊長為此值的正方形內。值越大，相同手指移動產生的手勢幅度越大。</string>
 
     <!-- Connection -->
     <string name="socket_path_label">守護程序 socket 路徑</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -35,7 +35,7 @@
 
     <!-- Accessibility -->
     <string name="accessibility_switch">無障礙按鍵攔截</string>
-    <string name="accessibility_hint">透過無障礙服務攔截功能鍵（Fn、F1-F12 等）。如果外接鍵盤的 Fn 組合鍵無法傳到桌面，請啟用此項。需要在系統 設定 &gt; 無障礙 中授予無障礙權限（僅需一次）。</string>
+    <string name="accessibility_hint">透過無障礙服務攔截功能鍵（Fn、F1-F12 等），並將平板鍵盤回報的返回／瀏覽器上一頁鍵轉換為 ESC。如果外接鍵盤的 Fn 組合鍵或 ESC 無法正確傳到桌面，請啟用此項。需要在系統 設定 &gt; 無障礙 中授予無障礙權限（僅需一次）。</string>
 
     <!-- Extra keys bar -->
     <string name="extra_keys_switch">擴充按鍵列（特殊按鍵）</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -63,6 +63,18 @@
     <string name="transform_captured_pointer_label">转换捕获的指针移动</string>
     <string name="captured_pointer_speed_label">捕获的指针速度系数，%</string>
     <string name="captured_pointer_speed_value">%1$d%%</string>
+    <string name="scroll_reverse_switch">反向捕获触摸板滚动</string>
+    <string name="scroll_reverse_hint">开启后内容跟随手指移动（“自然滚动”）。仅对捕获的硬件触摸板双指滚动生效。</string>
+    <string name="scroll_speed_label">双指滚动速度</string>
+    <string name="scroll_speed_value">%1$.2f</string>
+    <string name="threshold_factor_value">%1$.2f 倍触摸阈值</string>
+    <string name="scroll_threshold_label">滚动判定阈值</string>
+    <string name="scroll_threshold_hint">手指移动多远才算开始移动。如果双指开合被当成滚动，请调低此值。</string>
+    <string name="move_threshold_label">手势定性阈值</string>
+    <string name="move_threshold_hint">主导手指移动多远才对含糊的双指手势定性。如果滚动起步迟滞，请调低此值。</string>
+    <string name="gesture_scale_label">手势幅度</string>
+    <string name="gesture_scale_value">%1$.0f 像素</string>
+    <string name="gesture_scale_hint">转为触摸的手势（双指开合、三指及以上）会映射到以指针为中心、边长为此值的正方形内。值越大，相同手指移动产生的手势幅度越大。</string>
 
     <!-- Connection -->
     <string name="socket_path_label">守护进程套接字路径</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -35,7 +35,7 @@
 
     <!-- Accessibility -->
     <string name="accessibility_switch">无障碍按键拦截</string>
-    <string name="accessibility_hint">通过无障碍服务拦截功能键（Fn、F1-F12 等）。如果外接键盘的 Fn 组合键无法传到桌面，请启用此项。需要在系统 设置 &gt; 无障碍 中授予无障碍权限（仅需一次）。</string>
+    <string name="accessibility_hint">通过无障碍服务拦截功能键（Fn、F1-F12 等），并将平板键盘上报的返回/浏览器后退键转换为 ESC。如果外接键盘的 Fn 组合键或 ESC 无法正确传到桌面，请启用此项。需要在系统 设置 &gt; 无障碍 中授予无障碍权限（仅需一次）。</string>
 
     <!-- Extra keys bar -->
     <string name="extra_keys_switch">扩展按键栏（特殊按键）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,18 @@
     <string name="transform_captured_pointer_label">Transform captured pointer movements</string>
     <string name="captured_pointer_speed_label">Captured pointer speed factor, %</string>
     <string name="captured_pointer_speed_value">%1$d%%</string>
+    <string name="scroll_reverse_switch">Reverse captured touchpad scrolling</string>
+    <string name="scroll_reverse_hint">ON: content follows your fingers ("natural" scrolling). Applies to two-finger scrolling on captured hardware touchpads.</string>
+    <string name="scroll_speed_label">Two-finger scroll speed</string>
+    <string name="scroll_speed_value">%1$.2f</string>
+    <string name="threshold_factor_value">%1$.2f× touch slop</string>
+    <string name="scroll_threshold_label">Scroll detection threshold</string>
+    <string name="scroll_threshold_hint">How far a finger must travel before it counts as moving. Lower this if a pinch is being treated as a scroll.</string>
+    <string name="move_threshold_label">Gesture commit threshold</string>
+    <string name="move_threshold_hint">How far the leading finger must travel before an ambiguous two-finger gesture is resolved. Lower this if scrolling is slow to engage.</string>
+    <string name="gesture_scale_label">Gesture magnitude</string>
+    <string name="gesture_scale_value">%1$.0f px</string>
+    <string name="gesture_scale_hint">Gestures forwarded as touch (pinch, three or more fingers) are mapped into a square of this size centred on the pointer. Larger values make the same finger movement travel further.</string>
 
     <!-- Connection -->
     <string name="socket_path_label">Daemon socket path</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
 
     <!-- Accessibility -->
     <string name="accessibility_switch">Accessibility Key Interception</string>
-    <string name="accessibility_hint">Intercept function keys (Fn, F1-F12 etc.) via AccessibilityService. Enable this if external keyboard Fn combos don\'t reach the desktop. Requires Accessibility permission granted in system Settings &gt; Accessibility (one-time).</string>
+    <string name="accessibility_hint">Intercept function keys (Fn, F1-F12 etc.) via AccessibilityService and convert tablet-keyboard Back/Browser Back to ESC. Enable this if external keyboard Fn combos or ESC don\'t reach the desktop correctly. Requires Accessibility permission granted in system Settings &gt; Accessibility (one-time).</string>
 
     <!-- Extra keys bar -->
     <string name="extra_keys_switch">Extra Keys Bar (special keys)</string>


### PR DESCRIPTION
- app: convert intercepted Back keys to Escape

  When accessibility key interception is enabled, translate Android KEYCODE_BACK and Linux KEY_BACK scan code 158 from tablet keyboards to Linux Escape. Keep normal Android Back and configured user-action behavior unchanged when interception is disabled.

  Update the accessibility setting description in all supported locales.

  This backports upstream https://github.com/superturtlee/anland/commit/bc0b135980d0d2ad5ba1cb80b51162880b01acca (https://github.com/superturtlee/anland/pull/52)

- app: improve captured hardware touchpad handling

  Route captured pointer events through the root view and distinguish hardware touchpads from relative mice. Add gesture recognition, batched motion and scroll handling, coordinate fallback, button-state cleanup, and physical click-drag without changing the Anland protocol or backend.

- app: add captured touchpad gesture tuning

  Add settings for natural scrolling, two-finger scroll speed, gesture classification thresholds, and forwarded gesture magnitude.

  Apply these preferences to captured hardware touchpads while preserving the existing on-screen touchpad, pointer capture controls, and protocol behavior.