### PR TITLE
app: run SharedUID components in Termux process

### DIFF
--- a/app/src/standard/AndroidManifest.xml
+++ b/app/src/standard/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     android:sharedUserId="com.termux">
+    <application>
+        <!-- Keeps Anland Termux's process from being classified separately from Termux's own cpuset. -->
+        <activity android:name=".MainActivity" android:process="com.termux" />
+        <activity android:name=".SettingsActivity" android:process="com.termux" />
+        <receiver android:name=".UserActionReceiver" android:process="com.termux" />
+        <service android:name=".KeyInterceptor" android:process="com.termux" />
+    </application>
 </manifest>


### PR DESCRIPTION
Set the standard flavor's activities, receiver, and accessibility service to android:process="com.termux" so they run in the same process as Termux. Leave the compatible flavor unchanged.